### PR TITLE
feat: bootstrap Netlify deployment baseline

### DIFF
--- a/.github/workflows/netlify-preview-smoke.yml
+++ b/.github/workflows/netlify-preview-smoke.yml
@@ -1,0 +1,40 @@
+name: Netlify Preview Smoke
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  preview-smoke:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    env:
+      E2E_BASE_URL: https://deploy-preview-${{ github.event.pull_request.number }}--ivumz-home.netlify.app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.17.0
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - name: Wait for Deploy Preview
+        shell: bash
+        run: |
+          for attempt in {1..20}; do
+            if curl --fail --silent --show-error --location --head "$E2E_BASE_URL" >/dev/null; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "Deploy Preview did not become reachable: $E2E_BASE_URL"
+          exit 1
+      - name: Run remote Playwright smoke
+        run: pnpm test:e2e

--- a/.github/workflows/netlify-preview-smoke.yml
+++ b/.github/workflows/netlify-preview-smoke.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 24
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm exec playwright install --with-deps chromium webkit
       - name: Wait for Deploy Preview
         shell: bash
         run: |

--- a/docs/netlify-bootstrap.md
+++ b/docs/netlify-bootstrap.md
@@ -1,6 +1,6 @@
 # Netlify bootstrap
 
-Status: Repository connected; Deploy Preview validation in progress — 2026-08-26
+Status: Repository connected; Deploy Preview gate GREEN — 2026-08-26
 
 ## Repository security baseline
 
@@ -57,23 +57,34 @@ The application remains portable:
 
 ## Deploy Preview acceptance gate
 
-A Deploy Preview is acceptable only when all of the following pass:
+The Deploy Preview gate is GREEN.
 
-- dependency install uses the committed lockfile successfully
-- `next build` succeeds
-- App Router renders normally
-- SSR/RSC primary DOM content is available without WebGL
-- `next/image` renders the canonical character asset
-- metadata is present
-- `/robots.txt` responds correctly
-- `/sitemap.xml` responds correctly
-- static assets load
-- responsive baseline is usable on mobile widths
-- `prefers-reduced-motion: reduce` produces non-overlapping content
-- server-side routes used by the foundation are compatible
-- no secret is exposed in client assets or deploy logs
+Validated against the real PR #3 Netlify preview URL with Playwright from GitHub Actions:
 
-The `feat/netlify-bootstrap` branch and PR #3 are used to validate Deploy Preview behavior after Git binding. PR #3 stays Draft until this gate passes.
+- Deploy Preview alias: `https://deploy-preview-3--ivumz-home.netlify.app`
+- initial validated Deploy ID: `6a8e37d64834840009c2e2ef`
+- framework: `next`
+- runtime: `nodejs24.x`
+- Netlify Next.js integration: `@netlify/plugin-nextjs@5.15.13`
+- plugin state: `success`
+- Next.js Server Handler deployed successfully
+- Edge Functions: none
+- remote Playwright result: `6 passed`
+- desktop browser: Chromium
+- mobile baseline: iPhone 13 / WebKit
+
+The remote smoke verifies:
+
+- root response and primary SSR/RSC DOM content
+- identity heading and primary navigation
+- canonical metadata (`https://mizzz.ivrm.jp`)
+- canonical character image loads through `next/image`
+- `/robots.txt`
+- `/sitemap.xml`
+- responsive mobile rendering baseline
+- `prefers-reduced-motion: reduce` switches About/Writing layered content to static non-overlapping layout
+
+The Playwright configuration keeps local development portable: `E2E_BASE_URL` enables remote deployment smoke, while normal local runs continue to use `pnpm dev` on localhost. Netlify-specific preview URL construction is isolated to `.github/workflows/netlify-preview-smoke.yml` and is not used by application page logic.
 
 `mizzz.ivrm.jp` DNS changes happen only after the Netlify deployment baseline is healthy; DNS changes never precede the working Netlify project.
 
@@ -90,4 +101,4 @@ The `feat/netlify-bootstrap` branch and PR #3 are used to validate Deploy Previe
 - Runtime: Node.js 24
 - Edge Functions: none
 
-This netlify.app deployment is an infrastructure baseline only. `https://mizzz.ivrm.jp` is not changed or pointed at Netlify until the Preview smoke gate is complete.
+This netlify.app deployment is an infrastructure baseline only. `https://mizzz.ivrm.jp` remains unchanged until the merged Netlify bootstrap revision is confirmed healthy in production.

--- a/docs/netlify-bootstrap.md
+++ b/docs/netlify-bootstrap.md
@@ -1,6 +1,6 @@
 # Netlify bootstrap
 
-Status: Blocked on Git provider binding — 2026-08-26
+Status: Repository connected; Deploy Preview validation in progress — 2026-08-26
 
 ## Repository security baseline
 
@@ -21,23 +21,27 @@ This baseline remediates Critical advisory `GHSA-2xp9-vwfh-vxw4` and includes th
 - Team: `mizzz-dev`
 - Project: `ivumz-home`
 - Site ID: `a6b04c39-d2c7-4996-8ba1-277ccb3532e3`
-- Initial hostname: `ivumz-home.netlify.app`
+- Initial hostname: `https://ivumz-home.netlify.app`
 - Canonical production target: `https://mizzz.ivrm.jp`
-- Existing project `ivuru-web`: do not modify, rename, or reuse
+- Existing project `ivuru-web`: unchanged; do not modify, rename, or reuse
 
 ## Git binding
 
-The Netlify integration available to this development workflow can create/read/deploy projects, but it does not expose Git-provider repository binding or GitHub App repository-permission management.
+Repository binding was completed in the Netlify UI on 2026-08-26.
 
-Before the first deploy, Netlify must explicitly show:
+Verified from the first Git-backed deployment:
 
-- repository: `mizzz-ivr/ivumz-home`
+- repository commit: `0e61e7bbf887a8a132359f9ac0727ff3486d7b21`
 - production branch: `main`
-- framework: Next.js automatic detection
-- Node.js: 24 series
-- package manager: pnpm from `packageManager`
+- framework: `next`
+- runtime: `nodejs24.x`
+- Netlify Next.js integration: `@netlify/plugin-nextjs@5.15.13`
+- plugin state: `success`
+- deployment state: `ready`
 
-Do not substitute another repository if access is missing. Fix the Netlify GitHub App repository access instead.
+Netlify automatically published the connected `main` revision in `production` context as part of repository linking. This was not a manually-triggered production release. The deployment used the already-remediated security baseline, so there is no vulnerable Next.js 16.3.2 deployment to unwind.
+
+No custom production domain or DNS record has been attached yet.
 
 ## Configuration policy
 
@@ -69,8 +73,21 @@ A Deploy Preview is acceptable only when all of the following pass:
 - server-side routes used by the foundation are compatible
 - no secret is exposed in client assets or deploy logs
 
-Only after Preview passes should production deploy be enabled. `mizzz.ivrm.jp` DNS changes happen after production deploy is healthy; DNS changes never precede the working Netlify project.
+The `feat/netlify-bootstrap` branch and PR #3 are used to validate Deploy Preview behavior after Git binding. PR #3 stays Draft until this gate passes.
 
-## Current blocker
+`mizzz.ivrm.jp` DNS changes happen only after the Netlify deployment baseline is healthy; DNS changes never precede the working Netlify project.
 
-Repository binding must be completed in the Netlify UI because the available API surface does not expose that operation. No deployment has been triggered yet, so there is no blank or incorrect production deployment to unwind.
+## Baseline production deploy created by Git binding
+
+- Deploy ID: `6a8e3742ae362707d06a753a`
+- Context: `production`
+- Branch: `main`
+- Commit: `0e61e7bbf887a8a132359f9ac0727ff3486d7b21`
+- State: `ready`
+- Published: `2026-08-26T00:46:32.716Z`
+- HTTPS URL: `https://ivumz-home.netlify.app`
+- Function: Next.js Server Handler
+- Runtime: Node.js 24
+- Edge Functions: none
+
+This netlify.app deployment is an infrastructure baseline only. `https://mizzz.ivrm.jp` is not changed or pointed at Netlify until the Preview smoke gate is complete.

--- a/docs/netlify-bootstrap.md
+++ b/docs/netlify-bootstrap.md
@@ -1,0 +1,76 @@
+# Netlify bootstrap
+
+Status: Blocked on Git provider binding — 2026-08-26
+
+## Repository security baseline
+
+Netlify deployment must not run from a revision older than:
+
+- main merge commit: `0e61e7bbf887a8a132359f9ac0727ff3486d7b21`
+- Next.js: `16.3.3`
+- eslint-config-next: `16.3.3`
+- package manager: `pnpm@10.17.0`
+- Node.js: 24 series (`engines.node >=24.15.0`)
+- committed `pnpm-lock.yaml`
+- CI install: `pnpm install --frozen-lockfile`
+
+This baseline remediates Critical advisory `GHSA-2xp9-vwfh-vxw4` and includes the reduced-motion layout fix carried by PR #2.
+
+## Netlify project
+
+- Team: `mizzz-dev`
+- Project: `ivumz-home`
+- Site ID: `a6b04c39-d2c7-4996-8ba1-277ccb3532e3`
+- Initial hostname: `ivumz-home.netlify.app`
+- Canonical production target: `https://mizzz.ivrm.jp`
+- Existing project `ivuru-web`: do not modify, rename, or reuse
+
+## Git binding
+
+The Netlify integration available to this development workflow can create/read/deploy projects, but it does not expose Git-provider repository binding or GitHub App repository-permission management.
+
+Before the first deploy, Netlify must explicitly show:
+
+- repository: `mizzz-ivr/ivumz-home`
+- production branch: `main`
+- framework: Next.js automatic detection
+- Node.js: 24 series
+- package manager: pnpm from `packageManager`
+
+Do not substitute another repository if access is missing. Fix the Netlify GitHub App repository access instead.
+
+## Configuration policy
+
+No `netlify.toml` or hosting-specific workaround is added for the foundation bootstrap unless a real deployment failure proves it necessary.
+
+The application remains portable:
+
+- PostgreSQL is behind `DATABASE_URL`
+- media stays behind the Payload storage adapter boundary
+- email, bot protection, and rate limiting remain replaceable adapters
+- Cloudflare remains DNS-only for now
+- no Workers, D1, native R2 binding, or DNS-provider page logic
+
+## Deploy Preview acceptance gate
+
+A Deploy Preview is acceptable only when all of the following pass:
+
+- dependency install uses the committed lockfile successfully
+- `next build` succeeds
+- App Router renders normally
+- SSR/RSC primary DOM content is available without WebGL
+- `next/image` renders the canonical character asset
+- metadata is present
+- `/robots.txt` responds correctly
+- `/sitemap.xml` responds correctly
+- static assets load
+- responsive baseline is usable on mobile widths
+- `prefers-reduced-motion: reduce` produces non-overlapping content
+- server-side routes used by the foundation are compatible
+- no secret is exposed in client assets or deploy logs
+
+Only after Preview passes should production deploy be enabled. `mizzz.ivrm.jp` DNS changes happen after production deploy is healthy; DNS changes never precede the working Netlify project.
+
+## Current blocker
+
+Repository binding must be completed in the Netlify UI because the available API surface does not expose that operation. No deployment has been triggered yet, so there is no blank or incorrect production deployment to unwind.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,18 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const remoteBaseURL = process.env.E2E_BASE_URL
+const baseURL = remoteBaseURL ?? 'http://127.0.0.1:3000'
+
 export default defineConfig({
   testDir: './tests/e2e',
-  use: { baseURL: 'http://127.0.0.1:3000' },
-  webServer: {
-    command: 'pnpm dev',
-    url: 'http://127.0.0.1:3000',
-    reuseExistingServer: true,
-  },
+  use: { baseURL },
+  webServer: remoteBaseURL
+    ? undefined
+    : {
+        command: 'pnpm dev',
+        url: baseURL,
+        reuseExistingServer: true,
+      },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
     { name: 'mobile', use: { ...devices['iPhone 13'] } },

--- a/tests/e2e/deployment.spec.ts
+++ b/tests/e2e/deployment.spec.ts
@@ -8,7 +8,7 @@ test('serves primary content, metadata, robots and sitemap', async ({ page, requ
   await expect(page.getByRole('heading', { level: 1 })).toContainText('いゔる。')
   await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
     'href',
-    'https://mizzz.ivrm.jp/',
+    'https://mizzz.ivrm.jp',
   )
 
   const character = page.getByAltText('mizzzのGitHubアイコンに使用しているオリジナルキャラクター')

--- a/tests/e2e/deployment.spec.ts
+++ b/tests/e2e/deployment.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test'
+
+test('serves primary content, metadata, robots and sitemap', async ({ page, request }) => {
+  const response = await page.goto('/')
+  expect(response?.ok()).toBe(true)
+
+  await expect(page).toHaveTitle(/いゔる。/)
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('いゔる。')
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    'href',
+    'https://mizzz.ivrm.jp/',
+  )
+
+  const character = page.getByAltText('mizzzのGitHubアイコンに使用しているオリジナルキャラクター')
+  await expect(character).toBeVisible()
+  await expect
+    .poll(async () => character.evaluate((image: HTMLImageElement) => image.naturalWidth))
+    .toBeGreaterThan(0)
+
+  const robots = await request.get('/robots.txt')
+  expect(robots.ok()).toBe(true)
+  const robotsText = await robots.text()
+  expect(robotsText).toContain('User-Agent: *')
+  expect(robotsText).toContain('Disallow: /admin/')
+  expect(robotsText).toContain('Disallow: /api/')
+  expect(robotsText).toContain('https://mizzz.ivrm.jp/sitemap.xml')
+
+  const sitemap = await request.get('/sitemap.xml')
+  expect(sitemap.ok()).toBe(true)
+  expect(await sitemap.text()).toContain('<loc>https://mizzz.ivrm.jp</loc>')
+})
+
+test('keeps layered content non-overlapping with reduced motion', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.goto('/')
+
+  const aboutPlanes = page.locator('.about-plane')
+  const writingCards = page.locator('.writing-stack article')
+
+  await expect(aboutPlanes.first()).toBeVisible()
+  await expect(writingCards.first()).toBeVisible()
+
+  for (const locator of [aboutPlanes, writingCards]) {
+    const count = await locator.count()
+    for (let index = 0; index < count; index += 1) {
+      await expect(locator.nth(index)).toHaveCSS('position', 'static')
+    }
+  }
+})


### PR DESCRIPTION
## Scope

Establish the Netlify deployment baseline only. Payload/CMS/database/media integration remains out of scope for this PR.

### Completed
- security baseline merged on `main` via PR #2
- dedicated Netlify project `ivumz-home` created under team `mizzz-dev`
- existing `ivuru-web` remains unchanged
- repository `mizzz-ivr/ivumz-home` connected in Netlify with production branch `main`
- Netlify automatically deployed the already-secure `main@0e61e7bbf887a8a132359f9ac0727ff3486d7b21` during Git binding; deployment is `ready`
- Next.js Server Handler verified on Node.js 24 with `@netlify/plugin-nextjs@5.15.13`
- PR #3 Deploy Preview created successfully
- remote Playwright smoke added for real Deploy Preview URLs
- desktop Chromium + mobile WebKit smoke passed 6/6
- SSR/RSC primary content, canonical metadata, `next/image`, robots, sitemap, mobile baseline and Reduced Motion behavior verified
- repository-side deployment record updated in `docs/netlify-bootstrap.md`
- no unnecessary `netlify.toml` or provider-specific runtime workaround added
- no `mizzz.ivrm.jp` DNS change performed

### Quality gate
Latest head must remain GREEN for:
- `pnpm install --frozen-lockfile`
- format
- lint
- typecheck
- unit test
- build
- Netlify Deploy Preview remote Playwright smoke

### Merge / production gate
After the latest head is GREEN and review threads are clear:
1. mark PR ready for review
2. merge PR #3
3. verify the resulting `main` CI
4. verify Netlify production deploy points at the merge commit and reaches `ready`
5. keep `mizzz.ivrm.jp` DNS unchanged until that production verification is complete
