### PR TITLE
docs: ivmz identity / domain / contact方針を反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
-# ivumz-home
+# ivmz-home
 
-Public repository for **いゔる。 a.k.a. mizzz（ずーみー）** — a Personal Web Platform for portfolio, case studies, writing, news, public schedule, social links, and contact conversion.
+Public repository for **ivmz** — the unified personal web platform for **いゔる。 a.k.a. mizzz（ずーみー）**. It covers portfolio, case studies, writing, news, public schedule, social links, and contact conversion.
 
-- Production canonical: <https://mizzz.ivrm.jp>
+- Production canonical: <https://ivmz.ivrm.jp>
 - Community / Team root: <https://ivrm.jp>
 - GitHub: <https://github.com/mizzz-ivr>
-- Personal contact: `mizzz@ivrm.jp`
+- General / Personal contact: `ivmz@ivrm.jp`
+- Person-facing identity: `ivuru@ivrm.jp`
+- Developer / OSS identity: `mizzz@ivrm.jp`
 - Team contact: `contact@ivrm.jp`
 - Security: `security@ivrm.jp`
+- Legacy mail alias: `contact@mizzz.jp`
+
+## Identity model
+
+`ivmz` is the unified personal identity slug used for the canonical URL, general personal contact, and Personal Web Platform naming.
+
+- **ivmz** — unified personal identity / URL / general personal mail
+- **いゔる。** — SNS / creator / person-facing identity
+- **mizzz** — developer / OSS / technical identity
+- **ivRooom** — team / community / ecosystem
+
+Public contact surfaces should normally expose only:
+
+- General / Personal → `ivmz@ivrm.jp`
+- ivRooom / Team → `contact@ivrm.jp`
+- Security → `security@ivrm.jp`
+
+`ivuru@ivrm.jp` and `mizzz@ivrm.jp` remain valid role-specific From / Reply identities and may be used according to the context of the conversation.
+
+See `docs/identity-contact.md`.
 
 ## Identity / design rule
 
@@ -54,7 +76,7 @@ Reasons:
 - current Netlify Next.js runtime supports App Router, SSR, RSC, Streaming, Server Actions and `next/after`
 - AWS Amplify's documented managed Next.js support is currently through Next.js 15, which conflicts with the Next.js 16 direction
 - Payload can run anywhere Next.js runs, including Netlify and AWS
-- DNS is intentionally outside application architecture so `mizzz.ivrm.jp` can move from Cloudflare DNS to Amazon Route 53 later without rewriting the application
+- DNS is intentionally outside application architecture so `ivmz.ivrm.jp` can move from Cloudflare DNS to Amazon Route 53 later without rewriting the application
 
 AWS-first remains a future option, likely via ECS/Fargate + RDS/Aurora PostgreSQL + S3 + SES + Route 53 when the operational value justifies it.
 
@@ -114,6 +136,7 @@ pnpm build
 
 ## Docs
 
+- `docs/identity-contact.md`
 - `docs/architecture.md`
 - `docs/hosting.md`
 - `docs/design-direction.md`

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,8 +1,10 @@
-# Hosting decision — 2026-08-25
+# Hosting decision — 2026-08-26
 
 ## Goal
 
-Choose a launch host without coupling the application to the current DNS provider. `mizzz.ivrm.jp` should be able to move from Cloudflare DNS to Amazon Route 53 later without a product rewrite.
+Choose a launch host without coupling the application to the current DNS provider. `ivmz.ivrm.jp` should be able to move from Cloudflare DNS to Amazon Route 53 later without a product rewrite.
+
+The Personal Web Platform repository is `mizzz-ivr/ivmz-home`. Identity / contact decisions are documented in `docs/identity-contact.md`.
 
 ## Best launch option: Netlify
 
@@ -22,6 +24,14 @@ Route/DNS (temporary Cloudflare -> future Route 53)
       -> AWS S3 media
       -> Email adapter
 ```
+
+Canonical production host:
+
+```text
+https://ivmz.ivrm.jp
+```
+
+`mizzz.jp` is legacy / old-link compatibility and should redirect to `ivmz.ivrm.jp` for Web traffic.
 
 ## AWS option
 
@@ -49,6 +59,20 @@ This is more operationally involved than Netlify and is not necessary for the fi
 ### App Runner
 
 Do not adopt as a new default. AWS states App Runner stopped accepting new customers on 2026-03-31. Existing eligible accounts are a special case, not the baseline architecture.
+
+## Email boundary
+
+Keep email behind an application adapter.
+
+Current identity-level mail roles:
+
+- General / Personal → `ivmz@ivrm.jp`
+- Person-facing → `ivuru@ivrm.jp`
+- Developer / OSS → `mizzz@ivrm.jp`
+- ivRooom / Team → `contact@ivrm.jp`
+- Security → `security@ivrm.jp`
+
+Cloudflare Email Service / Email Sending SMTP is under evaluation for outbound mail. Do not couple product code directly to Cloudflare-specific primitives; keep provider-specific behavior at the adapter / deployment boundary.
 
 ## Portability rules
 

--- a/docs/identity-contact.md
+++ b/docs/identity-contact.md
@@ -1,0 +1,107 @@
+# Identity / Domain / Contact Architecture
+
+## Status
+
+2026-08-26 confirmed direction.
+
+Notion `35_Brand / Identity / Domain / Contact Architecture 2026-08-26` is the long-term decision Source of Truth. This document mirrors the parts that affect `ivmz-home` implementation.
+
+## Identity
+
+| Layer | Name / slug | Role |
+| --- | --- | --- |
+| Unified personal | `ivmz` | Personal platform, canonical URL, general personal contact |
+| Person-facing | いゔる。 | SNS / creator / person-facing identity |
+| Developer | mizzz（ずーみー） | Developer / OSS / technical identity |
+| Team / ecosystem | ivRooom | Team / community / ecosystem |
+
+`ivmz` is a slug and unified identity layer. It does not replace the display name `いゔる。` or the developer identity `mizzz`.
+
+## Domain policy
+
+```text
+ivrm.jp
+  → ivRooom / Team / Community / Ecosystem
+
+ivmz.ivrm.jp
+  → Unified Personal Identity / Portfolio / canonical
+
+mizzz.jp
+  → legacy / old-link compatibility
+  → 301 Redirect to ivmz.ivrm.jp for Web
+```
+
+Rules:
+
+1. New personal portfolio links use `https://ivmz.ivrm.jp`.
+2. `https://ivrm.jp` remains the ivRooom root.
+3. `mizzz.jp` is not a new canonical Web URL.
+4. canonical / OGP / sitemap / Search Console should converge on `ivmz.ivrm.jp`.
+5. Repository name is `mizzz-ivr/ivmz-home`. `ivumz-home` is obsolete.
+
+## Mail architecture
+
+| Address | Role | Public use |
+| --- | --- | --- |
+| `ivmz@ivrm.jp` | Unified Personal / General | Primary personal contact for X, GitHub, portfolio and general inquiries |
+| `ivuru@ivrm.jp` | Person-facing | Role-specific From / Reply as いゔる。 |
+| `mizzz@ivrm.jp` | Developer / OSS | Role-specific From / Reply for technical work |
+| `contact@ivrm.jp` | ivRooom / Team | Team / community / project inquiries |
+| `security@ivrm.jp` | Security | Vulnerability / security reports |
+| `contact@mizzz.jp` | Legacy alias | Compatibility receive path; not the primary new contact |
+
+The normal public contact surface should expose three addresses:
+
+- General / Personal → `ivmz@ivrm.jp`
+- ivRooom / Team → `contact@ivrm.jp`
+- Security → `security@ivrm.jp`
+
+`ivuru@ivrm.jp` and `mizzz@ivrm.jp` remain valid identities for replies when the inquiry context calls for them.
+
+## Contact form routing
+
+Recommended application-level routing:
+
+```text
+General / Personal / Other
+  → ivmz@ivrm.jp
+
+Creator / SNS / いゔる。 context
+  → ivuru@ivrm.jp
+
+Technical / OSS / Developer context
+  → mizzz@ivrm.jp
+
+ivRooom / Community / Team
+  → contact@ivrm.jp
+
+Security
+  → security@ivrm.jp
+```
+
+The form does not need to ask visitors to understand the identity model. The category controls internal routing; replies can use the most appropriate identity From address.
+
+## Email delivery direction
+
+Inbound is currently based on Cloudflare Email Routing. Outbound is being evaluated with Cloudflare Email Service / Email Sending SMTP.
+
+Before changing outbound delivery:
+
+- preserve working inbound MX / routing
+- verify all intended recipient aliases
+- do not remove existing SES / Resend DNS merely because it looks old
+- keep API tokens and destination addresses out of Git / public screenshots
+- treat Workers Paid as an explicit implementation gate for Cloudflare Email Sending in the current account
+
+## Repository rename migration
+
+The repository has been renamed to `ivmz-home`.
+
+Old internal identifiers must be migrated before the Payload / PostgreSQL foundation is merged:
+
+- `ivumz_home` → `ivmz_home`
+- `ivumz_home_app` → `ivmz_home_app`
+- `mizzz.ivrm.jp` → `ivmz.ivrm.jp` where it represents the canonical site
+- general-contact `mizzz@ivrm.jp` → `ivmz@ivrm.jp`
+
+`mizzz@ivrm.jp` itself remains valid for Developer / OSS usage and must not be blindly replaced in technical-contact contexts.

--- a/docs/information-architecture.md
+++ b/docs/information-architecture.md
@@ -31,3 +31,45 @@
 8. Contact
 
 The signature scroll choreography may visually combine adjacent pieces, but URLs, headings and primary content remain semantic DOM.
+
+## Identity presentation
+
+The site canonical is `ivmz.ivrm.jp` and the unified personal identity slug is `ivmz`.
+
+The site should explain, rather than collapse, the role split:
+
+- `ivmz` — unified personal identity / platform / general contact
+- いゔる。 — person-facing / SNS / creator identity
+- mizzz — Developer / OSS / technical identity
+- ivRooom — Team / Community / Ecosystem
+
+## Contact page
+
+Visitors should not need to know which internal mailbox to choose before contacting.
+
+Recommended public categories:
+
+- General / Personal
+- Creator / SNS
+- Technical / OSS / Developer
+- ivRooom / Community / Team
+- Security
+- Other
+
+Application routing:
+
+```text
+General / Personal / Other -> ivmz@ivrm.jp
+Creator / SNS               -> ivuru@ivrm.jp
+Technical / OSS / Developer -> mizzz@ivrm.jp
+ivRooom / Team              -> contact@ivrm.jp
+Security                    -> security@ivrm.jp
+```
+
+The normal public contact surface should primarily show:
+
+- `ivmz@ivrm.jp`
+- `contact@ivrm.jp`
+- `security@ivrm.jp`
+
+`ivuru@ivrm.jp` and `mizzz@ivrm.jp` remain role-specific reply identities. `contact@mizzz.jp` is legacy compatibility and is not a new primary contact path.


### PR DESCRIPTION
## 概要

2026-08-26に確定したUnified Personal Identity `ivmz` 方針を、`ivmz-home` の公開ドキュメントへ反映します。

## 確定方針

- Unified Personal Identity: `ivmz`
- Personal canonical: `https://ivmz.ivrm.jp`
- Repository: `mizzz-ivr/ivmz-home`
- General / Personal: `ivmz@ivrm.jp`
- Person-facing: `ivuru@ivrm.jp`
- Developer / OSS: `mizzz@ivrm.jp`
- ivRooom / Team: `contact@ivrm.jp`
- Security: `security@ivrm.jp`
- Legacy alias: `contact@mizzz.jp`
- `mizzz.jp` Web trafficは将来 `ivmz.ivrm.jp` へ301 Redirect

## 変更

- `README.md`
  - `ivumz-home` / `mizzz.ivrm.jp` / Generalとしての`mizzz@ivrm.jp`を新方針へ更新
  - Identity modelを追加
- `docs/identity-contact.md`
  - Identity / Domain / Contact ArchitectureのRepository向け正本を追加
  - 問い合わせフォームroutingを定義
  - Email delivery / repository rename migration方針を整理
- `docs/hosting.md`
  - canonicalを`ivmz.ivrm.jp`へ更新
  - email adapter境界と用途別アドレスを追記
- `docs/information-architecture.md`
  - Identity presentationとContact category/routingを追加

## Payload PR #4との関係

このPRは長期ドキュメントのみを更新し、進行中のPayload / PostgreSQL Foundation PR #4のコードやmigrationは変更しません。

PR #4ではmerge前に別途以下を移行します。

- `ivumz_home` → `ivmz_home`
- `ivumz_home_app` → `ivmz_home_app`
- canonical用途の`mizzz.ivrm.jp` → `ivmz.ivrm.jp`
- General用途の`mizzz@ivrm.jp` → `ivmz@ivrm.jp`

`mizzz@ivrm.jp` 自体はDeveloper / OSS identityとして維持するため、機械的な全置換は行いません。

## Source of Truth

Notion `35_Brand / Identity / Domain / Contact Architecture 2026-08-26` を長期決定のSource of Truthとします。