### PR TITLE
feat: add Payload-backed dynamic detail routes

### DIFF
--- a/src/app/(site)/blog/[slug]/page.tsx
+++ b/src/app/(site)/blog/[slug]/page.tsx
@@ -73,7 +73,10 @@ export default async function BlogDetailPage({ params }: DetailPageProps) {
         description={<p>{post.excerpt}</p>}
         signal="WRITING / KNOWLEDGE"
       />
-      <PageSection title="Article profile" description={<p>公開日時・category・tagsをまとめます。</p>}>
+      <PageSection
+        title="Article profile"
+        description={<p>公開日時・category・tagsをまとめます。</p>}
+      >
         <dl className="detail-facts">
           <div>
             <dt>Category</dt>
@@ -113,7 +116,8 @@ export default async function BlogDetailPage({ params }: DetailPageProps) {
         {externalCanonical && post.canonicalUrl ? (
           <div className="external-publication">
             <p>
-              このページはサイト内の安定した導線とtaxonomyを保持するsummary pageです。本文の正本は外部公開先にあります。
+              このページはサイト内の安定した導線とtaxonomyを保持するsummary
+              pageです。本文の正本は外部公開先にあります。
             </p>
             <a href={post.canonicalUrl} target="_blank" rel="noreferrer">
               Read canonical article <span aria-hidden="true">↗</span>

--- a/src/app/(site)/blog/[slug]/page.tsx
+++ b/src/app/(site)/blog/[slug]/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { PageCTA, PageHero, PageSection } from '@/components/site/PageFoundation'
+import { createPageMetadata } from '@/lib/metadata'
+import { getPublishedPostBySlug } from '@/lib/payload-content'
+import { site } from '@/lib/site'
+
+export const revalidate = 300
+
+type DetailPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return 'Published'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Published'
+  return new Intl.DateTimeFormat('ja-JP', { dateStyle: 'long' }).format(date)
+}
+
+function normalizePathname(pathname: string) {
+  const normalized = pathname.replace(/\/+$/, '')
+  return normalized || '/'
+}
+
+function hasAlternateCanonical(path: string, canonicalUrl?: string | null) {
+  if (!canonicalUrl) return false
+
+  try {
+    const canonical = new URL(canonicalUrl)
+    const internal = new URL(path, site.url)
+    return (
+      canonical.origin !== internal.origin ||
+      normalizePathname(canonical.pathname) !== normalizePathname(internal.pathname)
+    )
+  } catch {
+    return false
+  }
+}
+
+export async function generateMetadata({ params }: DetailPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const post = await getPublishedPostBySlug(slug)
+
+  if (!post) return { robots: { index: false, follow: false } }
+
+  return createPageMetadata({
+    title: post.title,
+    description: post.excerpt,
+    path: `/blog/${encodeURIComponent(post.slug)}`,
+    canonicalUrl: post.canonicalUrl,
+  })
+}
+
+export default async function BlogDetailPage({ params }: DetailPageProps) {
+  const { slug } = await params
+  const post = await getPublishedPostBySlug(slug)
+  if (!post) notFound()
+
+  const path = `/blog/${encodeURIComponent(post.slug)}`
+  const externalCanonical = hasAlternateCanonical(path, post.canonicalUrl)
+
+  return (
+    <main id="main-content" className="route-page detail-page">
+      <Link className="detail-back-link" href="/blog">
+        <span aria-hidden="true">←</span> All writing
+      </Link>
+      <PageHero
+        index="BLOG / DETAIL"
+        title={post.title}
+        description={<p>{post.excerpt}</p>}
+        signal="WRITING / KNOWLEDGE"
+      />
+      <PageSection title="Article profile" description={<p>公開日時・category・tagsをまとめます。</p>}>
+        <dl className="detail-facts">
+          <div>
+            <dt>Category</dt>
+            <dd>{post.category}</dd>
+          </div>
+          <div>
+            <dt>Published</dt>
+            <dd>{formatDate(post.publishedAt)}</dd>
+          </div>
+          <div>
+            <dt>Tags</dt>
+            <dd>{post.tags?.length ?? 0}</dd>
+          </div>
+          <div>
+            <dt>Related works</dt>
+            <dd>{post.relatedWorks?.length ?? 0}</dd>
+          </div>
+        </dl>
+        {post.tags && post.tags.length > 0 && (
+          <ul className="detail-tags detail-tags-spaced" aria-label="Article tags">
+            {post.tags.map((tag) => (
+              <li key={tag}>{tag}</li>
+            ))}
+          </ul>
+        )}
+      </PageSection>
+      <PageSection
+        title={externalCanonical ? 'Original publication' : 'Article'}
+        description={
+          <p>
+            {externalCanonical
+              ? '外部canonicalを正本として扱い、このrouteでは本文を重複掲載しません。'
+              : 'CMSのMarkdown/plain-text baselineをHTMLとして解釈せず、安全なテキストで表示します。'}
+          </p>
+        }
+      >
+        {externalCanonical && post.canonicalUrl ? (
+          <div className="external-publication">
+            <p>
+              このページはサイト内の安定した導線とtaxonomyを保持するsummary pageです。本文の正本は外部公開先にあります。
+            </p>
+            <a href={post.canonicalUrl} target="_blank" rel="noreferrer">
+              Read canonical article <span aria-hidden="true">↗</span>
+            </a>
+          </div>
+        ) : (
+          <div className="detail-prose">
+            <p>{post.body}</p>
+          </div>
+        )}
+      </PageSection>
+      <PageCTA
+        title="Follow the latest activity."
+        body="短いリリース・告知・活動記録はNewsへ分離しています。"
+        href="/news"
+        label="Open News"
+      />
+    </main>
+  )
+}

--- a/src/app/(site)/blog/page.tsx
+++ b/src/app/(site)/blog/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 import { EmptyState, PageCTA, PageHero, PageSection } from '@/components/site/PageFoundation'
 import { createPageMetadata } from '@/lib/metadata'
 import { getPostsListContent } from '@/lib/public-list-content'
@@ -51,10 +53,11 @@ export default async function BlogPage() {
                       : 'PUBLISHED'}
                   </span>
                   <small>{post.tags?.join(' · ') || 'Writing'}</small>
-                  {post.canonicalUrl ? (
-                    <a href={post.canonicalUrl}>Read article ↗</a>
-                  ) : (
-                    <small>Detail route coming next</small>
+                  <Link href={`/blog/${encodeURIComponent(post.slug)}`}>Read details →</Link>
+                  {post.canonicalUrl && (
+                    <a href={post.canonicalUrl} target="_blank" rel="noreferrer">
+                      Original article ↗
+                    </a>
                   )}
                 </div>
               </article>

--- a/src/app/(site)/news/[slug]/page.tsx
+++ b/src/app/(site)/news/[slug]/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { PageCTA, PageHero, PageSection } from '@/components/site/PageFoundation'
+import { createPageMetadata } from '@/lib/metadata'
+import { getPublishedNewsBySlug } from '@/lib/payload-content'
+
+export const revalidate = 300
+
+type DetailPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return 'Published'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Published'
+  return new Intl.DateTimeFormat('ja-JP', { dateStyle: 'long' }).format(date)
+}
+
+function compact(value: string, maxLength = 260) {
+  const text = value.replace(/\s+/g, ' ').trim()
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text
+}
+
+export async function generateMetadata({ params }: DetailPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const item = await getPublishedNewsBySlug(slug)
+
+  if (!item) return { robots: { index: false, follow: false } }
+
+  return createPageMetadata({
+    title: item.title,
+    description: compact(item.body),
+    path: `/news/${encodeURIComponent(item.slug)}`,
+  })
+}
+
+export default async function NewsDetailPage({ params }: DetailPageProps) {
+  const { slug } = await params
+  const item = await getPublishedNewsBySlug(slug)
+  if (!item) notFound()
+
+  return (
+    <main id="main-content" className="route-page detail-page">
+      <Link className="detail-back-link" href="/news">
+        <span aria-hidden="true">←</span> All news
+      </Link>
+      <PageHero
+        index="NEWS / DETAIL"
+        title={item.title}
+        description={<p>{compact(item.body)}</p>}
+        signal="ACTIVITY / RELEASE"
+      />
+      <PageSection title="Update profile" description={<p>公開済みNewsのtypeと公開日。</p>}>
+        <dl className="detail-facts">
+          <div>
+            <dt>Type</dt>
+            <dd>{item.type}</dd>
+          </div>
+          <div>
+            <dt>Published</dt>
+            <dd>{formatDate(item.publishedAt)}</dd>
+          </div>
+        </dl>
+      </PageSection>
+      <PageSection title="Update" description={<p>News本文を安全なテキストとして表示します。</p>}>
+        <div className="detail-prose">
+          <p>{item.body}</p>
+        </div>
+      </PageSection>
+      {item.externalUrl && (
+        <PageSection title="Source" description={<p>内部News detailとは別の外部参照先です。</p>}>
+          <div className="detail-actions">
+            <a href={item.externalUrl} target="_blank" rel="noreferrer">
+              Open external source <span aria-hidden="true">↗</span>
+            </a>
+          </div>
+        </PageSection>
+      )}
+      <PageCTA
+        title="See what comes next."
+        body="公開予定・イベント・リリース予定はScheduleへ。"
+        href="/schedule"
+        label="Open Schedule"
+      />
+    </main>
+  )
+}

--- a/src/app/(site)/news/page.tsx
+++ b/src/app/(site)/news/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 import { EmptyState, PageCTA, PageHero, PageSection } from '@/components/site/PageFoundation'
 import { createPageMetadata } from '@/lib/metadata'
 import { getNewsListContent } from '@/lib/public-list-content'
@@ -57,10 +59,11 @@ export default async function NewsPage() {
                       ? new Intl.DateTimeFormat('ja-JP').format(new Date(item.publishedAt))
                       : 'PUBLISHED'}
                   </span>
-                  {item.externalUrl ? (
-                    <a href={item.externalUrl}>Open source ↗</a>
-                  ) : (
-                    <small>Detail route coming next</small>
+                  <Link href={`/news/${encodeURIComponent(item.slug)}`}>Read update →</Link>
+                  {item.externalUrl && (
+                    <a href={item.externalUrl} target="_blank" rel="noreferrer">
+                      Open source ↗
+                    </a>
                   )}
                 </div>
               </article>

--- a/src/app/(site)/not-found.tsx
+++ b/src/app/(site)/not-found.tsx
@@ -1,0 +1,24 @@
+import { PageCTA, PageHero } from '@/components/site/PageFoundation'
+
+export default function NotFound() {
+  return (
+    <main id="main-content" className="route-page detail-page">
+      <PageHero
+        index="404 / NO SIGNAL"
+        title="Signal not found."
+        description={
+          <p>
+            このURLで公開中のコンテンツは見つかりません。未公開・draftの存在有無も公開routeからは区別しません。
+          </p>
+        }
+        signal="NOT FOUND / PRIVATE"
+      />
+      <PageCTA
+        title="Return to a public destination."
+        body="公開中のWorks・Blog・Newsは各一覧から辿れます。"
+        href="/"
+        label="Back home"
+      />
+    </main>
+  )
+}

--- a/src/app/(site)/pages.css
+++ b/src/app/(site)/pages.css
@@ -30,6 +30,7 @@
   line-height: 0.88;
   letter-spacing: -0.07em;
   text-wrap: balance;
+  overflow-wrap: anywhere;
 }
 .page-lede {
   max-width: 720px;
@@ -111,6 +112,7 @@
   font-size: clamp(1.4rem, 2.5vw, 2.15rem);
   line-height: 1.08;
   letter-spacing: -0.035em;
+  overflow-wrap: anywhere;
 }
 .content-row p {
   max-width: 720px;
@@ -119,6 +121,7 @@
 }
 .content-row-meta {
   display: flex;
+  min-width: 0;
   flex-direction: column;
   align-items: flex-start;
   gap: 12px;
@@ -126,12 +129,15 @@
 }
 .content-row-meta small {
   color: var(--color-muted);
+  overflow-wrap: anywhere;
 }
 .content-row-meta a,
 .inline-link {
   position: relative;
+  max-width: 100%;
   color: var(--color-text);
   font-weight: 700;
+  overflow-wrap: anywhere;
 }
 .content-row-meta a::after,
 .inline-link::after {
@@ -330,6 +336,107 @@
   margin-left: 18px;
 }
 
+.detail-back-link {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 10px;
+  color: var(--color-text-soft);
+  font: 700 0.72rem/1.2 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.detail-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  margin: 0;
+  background: var(--color-line);
+  border: 1px solid var(--color-line);
+}
+.detail-facts > div {
+  min-width: 0;
+  padding: clamp(22px, 3vw, 34px);
+  background: var(--color-bg);
+}
+.detail-facts dt {
+  color: var(--color-primary-soft);
+  font: 700 0.64rem/1.3 var(--font-mono);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.detail-facts dd {
+  margin: 10px 0 0;
+  color: var(--color-text);
+  font-size: clamp(1rem, 1.6vw, 1.24rem);
+  overflow-wrap: anywhere;
+}
+.detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.detail-tags-spaced {
+  margin-top: 24px;
+}
+.detail-tags li {
+  max-width: 100%;
+  padding: 10px 13px;
+  border: 1px solid var(--color-line-strong);
+  color: var(--color-text-soft);
+  font: 650 0.72rem/1.3 var(--font-mono);
+  overflow-wrap: anywhere;
+}
+.detail-list {
+  display: grid;
+  gap: 18px;
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--color-text-soft);
+}
+.detail-list li {
+  padding-left: 8px;
+  overflow-wrap: anywhere;
+}
+.detail-prose {
+  min-width: 0;
+  max-width: 820px;
+}
+.detail-prose p,
+.external-publication p {
+  margin: 0;
+  color: var(--color-text-soft);
+  font-size: clamp(1rem, 1.45vw, 1.14rem);
+  line-height: 1.85;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+}
+.detail-actions a,
+.external-publication a {
+  display: inline-flex;
+  min-height: 44px;
+  max-width: 100%;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  color: var(--color-text);
+  font-weight: 750;
+  overflow-wrap: anywhere;
+}
+.external-publication {
+  display: grid;
+  max-width: 820px;
+  gap: 24px;
+}
+
 @media (max-width: 760px) {
   .route-page {
     padding-top: 108px;
@@ -379,6 +486,9 @@
   }
   .link-directory small {
     grid-column: 2;
+  }
+  .detail-facts {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/app/(site)/works/[slug]/page.tsx
+++ b/src/app/(site)/works/[slug]/page.tsx
@@ -69,16 +69,11 @@ export default async function WorkDetailPage({ params }: DetailPageProps) {
           </div>
           <div>
             <dt>Media</dt>
-            <dd>
-              {mediaCount > 0 ? `${mediaCount} asset${mediaCount === 1 ? '' : 's'}` : 'None'}
-            </dd>
+            <dd>{mediaCount > 0 ? `${mediaCount} asset${mediaCount === 1 ? '' : 's'}` : 'None'}</dd>
           </div>
         </dl>
       </PageSection>
-      <PageSection
-        title="Technology"
-        description={<p>この制作物で使っている主要スタック。</p>}
-      >
+      <PageSection title="Technology" description={<p>この制作物で使っている主要スタック。</p>}>
         <ul className="detail-tags" aria-label="Technology stack">
           {work.stack.map((technology) => (
             <li key={technology}>{technology}</li>
@@ -116,10 +111,7 @@ export default async function WorkDetailPage({ params }: DetailPageProps) {
         )}
       </PageSection>
       {(work.githubUrl || work.liveUrl) && (
-        <PageSection
-          title="Links"
-          description={<p>内部Case Studyとは別の外部destinationです。</p>}
-        >
+        <PageSection title="Links" description={<p>内部Case Studyとは別の外部destinationです。</p>}>
           <div className="detail-actions">
             {work.githubUrl && (
               <a href={work.githubUrl} target="_blank" rel="noreferrer">

--- a/src/app/(site)/works/[slug]/page.tsx
+++ b/src/app/(site)/works/[slug]/page.tsx
@@ -75,7 +75,10 @@ export default async function WorkDetailPage({ params }: DetailPageProps) {
           </div>
         </dl>
       </PageSection>
-      <PageSection title="Technology" description={<p>この制作物で使っている主要スタック。</p>}>
+      <PageSection
+        title="Technology"
+        description={<p>この制作物で使っている主要スタック。</p>}
+      >
         <ul className="detail-tags" aria-label="Technology stack">
           {work.stack.map((technology) => (
             <li key={technology}>{technology}</li>

--- a/src/app/(site)/works/[slug]/page.tsx
+++ b/src/app/(site)/works/[slug]/page.tsx
@@ -69,7 +69,9 @@ export default async function WorkDetailPage({ params }: DetailPageProps) {
           </div>
           <div>
             <dt>Media</dt>
-            <dd>{mediaCount > 0 ? `${mediaCount} asset${mediaCount === 1 ? '' : 's'}` : 'None'}</dd>
+            <dd>
+              {mediaCount > 0 ? `${mediaCount} asset${mediaCount === 1 ? '' : 's'}` : 'None'}
+            </dd>
           </div>
         </dl>
       </PageSection>
@@ -80,7 +82,10 @@ export default async function WorkDetailPage({ params }: DetailPageProps) {
           ))}
         </ul>
       </PageSection>
-      <PageSection title="Highlights" description={<p>実装・設計上の要点を短く追えるようにします。</p>}>
+      <PageSection
+        title="Highlights"
+        description={<p>実装・設計上の要点を短く追えるようにします。</p>}
+      >
         {work.highlights && work.highlights.length > 0 ? (
           <ul className="detail-list">
             {work.highlights.map((highlight) => (
@@ -93,7 +98,10 @@ export default async function WorkDetailPage({ params }: DetailPageProps) {
           </EmptyState>
         )}
       </PageSection>
-      <PageSection title="Case study" description={<p>CMS上のCase Study本文を安全なテキストとして表示します。</p>}>
+      <PageSection
+        title="Case study"
+        description={<p>CMS上のCase Study本文を安全なテキストとして表示します。</p>}
+      >
         {work.caseStudy ? (
           <div className="detail-prose">
             <p>{work.caseStudy}</p>
@@ -105,7 +113,10 @@ export default async function WorkDetailPage({ params }: DetailPageProps) {
         )}
       </PageSection>
       {(work.githubUrl || work.liveUrl) && (
-        <PageSection title="Links" description={<p>内部Case Studyとは別の外部destinationです。</p>}>
+        <PageSection
+          title="Links"
+          description={<p>内部Case Studyとは別の外部destinationです。</p>}
+        >
           <div className="detail-actions">
             {work.githubUrl && (
               <a href={work.githubUrl} target="_blank" rel="noreferrer">

--- a/src/app/(site)/works/[slug]/page.tsx
+++ b/src/app/(site)/works/[slug]/page.tsx
@@ -1,0 +1,131 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { EmptyState, PageCTA, PageHero, PageSection } from '@/components/site/PageFoundation'
+import { createPageMetadata } from '@/lib/metadata'
+import { getPublishedWorkBySlug } from '@/lib/payload-content'
+
+export const revalidate = 300
+
+type DetailPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return 'Published'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Published'
+  return new Intl.DateTimeFormat('ja-JP', { dateStyle: 'long' }).format(date)
+}
+
+export async function generateMetadata({ params }: DetailPageProps): Promise<Metadata> {
+  const { slug } = await params
+  const work = await getPublishedWorkBySlug(slug)
+
+  if (!work) return { robots: { index: false, follow: false } }
+
+  return createPageMetadata({
+    title: work.title,
+    description: work.summary,
+    path: `/works/${encodeURIComponent(work.slug)}`,
+  })
+}
+
+export default async function WorkDetailPage({ params }: DetailPageProps) {
+  const { slug } = await params
+  const work = await getPublishedWorkBySlug(slug)
+  if (!work) notFound()
+
+  const mediaCount = work.gallery?.length ?? 0
+
+  return (
+    <main id="main-content" className="route-page detail-page">
+      <Link className="detail-back-link" href="/works">
+        <span aria-hidden="true">←</span> All works
+      </Link>
+      <PageHero
+        index="WORK / DETAIL"
+        title={work.title}
+        description={<p>{work.summary}</p>}
+        signal="CASE STUDY / BUILD"
+      />
+      <PageSection
+        title="Project profile"
+        description={<p>役割・状態・公開日と、公開Content Modelに登録された技術情報です。</p>}
+      >
+        <dl className="detail-facts">
+          <div>
+            <dt>Role</dt>
+            <dd>{work.role}</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd>{work.projectStatus}</dd>
+          </div>
+          <div>
+            <dt>Published</dt>
+            <dd>{formatDate(work.publishedAt)}</dd>
+          </div>
+          <div>
+            <dt>Media</dt>
+            <dd>{mediaCount > 0 ? `${mediaCount} asset${mediaCount === 1 ? '' : 's'}` : 'None'}</dd>
+          </div>
+        </dl>
+      </PageSection>
+      <PageSection title="Technology" description={<p>この制作物で使っている主要スタック。</p>}>
+        <ul className="detail-tags" aria-label="Technology stack">
+          {work.stack.map((technology) => (
+            <li key={technology}>{technology}</li>
+          ))}
+        </ul>
+      </PageSection>
+      <PageSection title="Highlights" description={<p>実装・設計上の要点を短く追えるようにします。</p>}>
+        {work.highlights && work.highlights.length > 0 ? (
+          <ul className="detail-list">
+            {work.highlights.map((highlight) => (
+              <li key={highlight}>{highlight}</li>
+            ))}
+          </ul>
+        ) : (
+          <EmptyState title="No highlights published yet.">
+            Highlightsが公開された時点でここに反映されます。
+          </EmptyState>
+        )}
+      </PageSection>
+      <PageSection title="Case study" description={<p>CMS上のCase Study本文を安全なテキストとして表示します。</p>}>
+        {work.caseStudy ? (
+          <div className="detail-prose">
+            <p>{work.caseStudy}</p>
+          </div>
+        ) : (
+          <EmptyState title="Case study is being prepared.">
+            routeとmetadataは利用可能なまま、本文未登録を明示します。
+          </EmptyState>
+        )}
+      </PageSection>
+      {(work.githubUrl || work.liveUrl) && (
+        <PageSection title="Links" description={<p>内部Case Studyとは別の外部destinationです。</p>}>
+          <div className="detail-actions">
+            {work.githubUrl && (
+              <a href={work.githubUrl} target="_blank" rel="noreferrer">
+                Open GitHub <span aria-hidden="true">↗</span>
+              </a>
+            )}
+            {work.liveUrl && (
+              <a href={work.liveUrl} target="_blank" rel="noreferrer">
+                Open live site <span aria-hidden="true">↗</span>
+              </a>
+            )}
+          </div>
+        </PageSection>
+      )}
+      <PageCTA
+        title="Read the implementation notes."
+        body="技術的な判断やBuild LogはBlogへ分離して蓄積します。"
+        href="/blog"
+        label="Open Blog"
+      />
+    </main>
+  )
+}

--- a/src/app/(site)/works/page.tsx
+++ b/src/app/(site)/works/page.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 import { EmptyState, PageCTA, PageHero, PageSection } from '@/components/site/PageFoundation'
 import { createPageMetadata } from '@/lib/metadata'
 import { getWorksListContent } from '@/lib/public-list-content'
@@ -11,7 +13,7 @@ export const metadata = createPageMetadata({
 })
 
 const copy = {
-  hero: '公開済みの制作物をPayload CMSから取得します。詳細Case Study routeは次PRでslugへ接続します。',
+  hero: '公開済みの制作物をPayload CMSから取得し、各Case Study detailへ接続します。',
   queryError:
     'CMS queryに失敗しました。Homeの既存fallbackは維持され、この一覧だけ安全に縮退しています。',
   empty: 'CMSは正常です。公開済みWorksが登録されるまで、このempty stateを表示します。',
@@ -48,9 +50,17 @@ export default async function WorksPage() {
                 <div className="content-row-meta">
                   <span>{work.role}</span>
                   <small>{work.stack.join(' · ')}</small>
-                  {work.githubUrl && <a href={work.githubUrl}>GitHub ↗</a>}
-                  {!work.githubUrl && work.liveUrl && <a href={work.liveUrl}>Live site ↗</a>}
-                  {!work.githubUrl && !work.liveUrl && <small>Detail route coming next</small>}
+                  <Link href={`/works/${encodeURIComponent(work.slug)}`}>View case study →</Link>
+                  {work.githubUrl && (
+                    <a href={work.githubUrl} target="_blank" rel="noreferrer">
+                      GitHub ↗
+                    </a>
+                  )}
+                  {work.liveUrl && (
+                    <a href={work.liveUrl} target="_blank" rel="noreferrer">
+                      Live site ↗
+                    </a>
+                  )}
                 </div>
               </article>
             ))}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,10 @@
 import type { MetadataRoute } from 'next'
+
+import { resolveCanonicalUrl } from '@/lib/metadata'
+import { getNewsListContent, getPostsListContent, getWorksListContent } from '@/lib/public-list-content'
 import { site } from '@/lib/site'
+
+export const revalidate = 300
 
 const staticRoutes = [
   '/',
@@ -14,10 +19,50 @@ const staticRoutes = [
   '/legal/terms',
 ] as const
 
-export default function sitemap(): MetadataRoute.Sitemap {
-  return staticRoutes.map((path) => ({
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const entries: MetadataRoute.Sitemap = staticRoutes.map((path) => ({
     url: new URL(path, site.url).toString(),
     changeFrequency: path === '/' ? 'weekly' : 'monthly',
     priority: path === '/' ? 1 : path.startsWith('/legal/') ? 0.3 : 0.7,
   }))
+
+  // Keep these sequential: the Netlify runtime intentionally limits Payload/PostgreSQL concurrency.
+  const works = await getWorksListContent(1_000)
+  const posts = await getPostsListContent(1_000)
+  const news = await getNewsListContent(1_000)
+
+  for (const work of works.items) {
+    const path = `/works/${encodeURIComponent(work.slug)}`
+    entries.push({
+      url: new URL(path, site.url).toString(),
+      lastModified: work.publishedAt ?? work.updatedAt,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    })
+  }
+
+  for (const post of posts.items) {
+    const path = `/blog/${encodeURIComponent(post.slug)}`
+    const internalCanonical = new URL(path, site.url).toString()
+    if (resolveCanonicalUrl(path, post.canonicalUrl) !== internalCanonical) continue
+
+    entries.push({
+      url: internalCanonical,
+      lastModified: post.publishedAt ?? post.updatedAt,
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    })
+  }
+
+  for (const item of news.items) {
+    const path = `/news/${encodeURIComponent(item.slug)}`
+    entries.push({
+      url: new URL(path, site.url).toString(),
+      lastModified: item.publishedAt ?? item.updatedAt,
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    })
+  }
+
+  return entries
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,11 @@
 import type { MetadataRoute } from 'next'
 
 import { resolveCanonicalUrl } from '@/lib/metadata'
-import { getNewsListContent, getPostsListContent, getWorksListContent } from '@/lib/public-list-content'
+import {
+  getNewsListContent,
+  getPostsListContent,
+  getWorksListContent,
+} from '@/lib/public-list-content'
 import { site } from '@/lib/site'
 
 export const revalidate = 300

--- a/src/lib/metadata.test.ts
+++ b/src/lib/metadata.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCanonicalUrl } from '@/lib/metadata'
+
+describe('canonical URL resolution', () => {
+  it('uses the production site URL for internal routes', () => {
+    expect(resolveCanonicalUrl('/works/example')).toBe('https://ivmz.ivrm.jp/works/example')
+  })
+
+  it('honors an explicit HTTP(S) canonical URL', () => {
+    expect(resolveCanonicalUrl('/blog/example', 'https://example.com/articles/example')).toBe(
+      'https://example.com/articles/example',
+    )
+  })
+
+  it('falls back to the internal canonical for unsafe or malformed values', () => {
+    expect(resolveCanonicalUrl('/blog/example', 'javascript:alert(1)')).toBe(
+      'https://ivmz.ivrm.jp/blog/example',
+    )
+    expect(resolveCanonicalUrl('/blog/example', 'not a url')).toBe(
+      'https://ivmz.ivrm.jp/blog/example',
+    )
+  })
+})

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -6,10 +6,32 @@ type PageMetadataInput = {
   title: string
   description: string
   path: string
+  canonicalUrl?: string | null
 }
 
-export function createPageMetadata({ title, description, path }: PageMetadataInput): Metadata {
-  const canonical = new URL(path, site.url).toString()
+export function resolveCanonicalUrl(path: string, canonicalUrl?: string | null) {
+  const fallback = new URL(path, site.url).toString()
+  if (!canonicalUrl) return fallback
+
+  try {
+    const candidate = new URL(canonicalUrl)
+    if (candidate.protocol === 'http:' || candidate.protocol === 'https:') {
+      return candidate.toString()
+    }
+  } catch {
+    // Invalid CMS data must never make metadata generation fail.
+  }
+
+  return fallback
+}
+
+export function createPageMetadata({
+  title,
+  description,
+  path,
+  canonicalUrl,
+}: PageMetadataInput): Metadata {
+  const canonical = resolveCanonicalUrl(path, canonicalUrl)
 
   return {
     title,

--- a/src/lib/payload-content.ts
+++ b/src/lib/payload-content.ts
@@ -2,6 +2,8 @@ import configPromise from '@payload-config'
 import { cache } from 'react'
 import { getPayload } from 'payload'
 
+import { createPublishedSlugWhere } from '@/lib/payload-detail-query'
+
 const getContentPayload = cache(() => getPayload({ config: configPromise }))
 
 export async function getPublishedWorks(limit = 3) {
@@ -57,6 +59,48 @@ export async function getLatestNews(limit = 3) {
     },
   })
 }
+
+export const getPublishedWorkBySlug = cache(async (slug: string) => {
+  const payload = await getContentPayload()
+  const result = await payload.find({
+    collection: 'works',
+    depth: 0,
+    draft: false,
+    limit: 1,
+    overrideAccess: false,
+    where: createPublishedSlugWhere(slug),
+  })
+
+  return result.docs[0] ?? null
+})
+
+export const getPublishedPostBySlug = cache(async (slug: string) => {
+  const payload = await getContentPayload()
+  const result = await payload.find({
+    collection: 'posts',
+    depth: 0,
+    draft: false,
+    limit: 1,
+    overrideAccess: false,
+    where: createPublishedSlugWhere(slug),
+  })
+
+  return result.docs[0] ?? null
+})
+
+export const getPublishedNewsBySlug = cache(async (slug: string) => {
+  const payload = await getContentPayload()
+  const result = await payload.find({
+    collection: 'news',
+    depth: 0,
+    draft: false,
+    limit: 1,
+    overrideAccess: false,
+    where: createPublishedSlugWhere(slug),
+  })
+
+  return result.docs[0] ?? null
+})
 
 export async function getUpcomingSchedule(limit = 3, now = new Date()) {
   const payload = await getContentPayload()

--- a/src/lib/payload-detail-query.test.ts
+++ b/src/lib/payload-detail-query.test.ts
@@ -5,10 +5,7 @@ import { createPublishedSlugWhere } from '@/lib/payload-detail-query'
 describe('published detail query contract', () => {
   it('matches the requested slug exactly and keeps published status mandatory', () => {
     expect(createPublishedSlugWhere('Exact-Slug')).toEqual({
-      and: [
-        { slug: { equals: 'Exact-Slug' } },
-        { _status: { equals: 'published' } },
-      ],
+      and: [{ slug: { equals: 'Exact-Slug' } }, { _status: { equals: 'published' } }],
     })
   })
 })

--- a/src/lib/payload-detail-query.test.ts
+++ b/src/lib/payload-detail-query.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { createPublishedSlugWhere } from '@/lib/payload-detail-query'
+
+describe('published detail query contract', () => {
+  it('matches the requested slug exactly and keeps published status mandatory', () => {
+    expect(createPublishedSlugWhere('Exact-Slug')).toEqual({
+      and: [
+        { slug: { equals: 'Exact-Slug' } },
+        { _status: { equals: 'published' } },
+      ],
+    })
+  })
+})

--- a/src/lib/payload-detail-query.ts
+++ b/src/lib/payload-detail-query.ts
@@ -1,4 +1,6 @@
-export function createPublishedSlugWhere(slug: string) {
+import type { Where } from 'payload'
+
+export function createPublishedSlugWhere(slug: string): Where {
   return {
     and: [
       {

--- a/src/lib/payload-detail-query.ts
+++ b/src/lib/payload-detail-query.ts
@@ -1,0 +1,16 @@
+export function createPublishedSlugWhere(slug: string) {
+  return {
+    and: [
+      {
+        slug: {
+          equals: slug,
+        },
+      },
+      {
+        _status: {
+          equals: 'published',
+        },
+      },
+    ],
+  }
+}

--- a/tests/e2e/dynamic-routes.spec.ts
+++ b/tests/e2e/dynamic-routes.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+
+type PublicDoc = {
+  title: string
+  slug: string
+  canonicalUrl?: string | null
+}
+
+const detailRoutes = [
+  {
+    collection: 'works',
+    listPath: '/works',
+    path: (slug: string) => `/works/${encodeURIComponent(slug)}`,
+    primaryLabel: 'View case study',
+    emptyHeading: 'No published works yet.',
+  },
+  {
+    collection: 'posts',
+    listPath: '/blog',
+    path: (slug: string) => `/blog/${encodeURIComponent(slug)}`,
+    primaryLabel: 'Read details',
+    emptyHeading: 'No published posts yet.',
+  },
+  {
+    collection: 'news',
+    listPath: '/news',
+    path: (slug: string) => `/news/${encodeURIComponent(slug)}`,
+    primaryLabel: 'Read update',
+    emptyHeading: 'No published news yet.',
+  },
+] as const
+
+const responsiveWidths = [320, 375, 390, 768, 1024, 1440] as const
+
+async function firstPublishedDoc(request: APIRequestContext, collection: string) {
+  const response = await request.get(`/api/${collection}?limit=1&depth=0`)
+  expect(response.status(), collection).toBe(200)
+  const payload = (await response.json()) as { docs: PublicDoc[] }
+  return payload.docs[0] ?? null
+}
+
+test('connects published list items to detail routes with h1, reload and metadata', async ({
+  page,
+  request,
+}) => {
+  for (const route of detailRoutes) {
+    const doc = await firstPublishedDoc(request, route.collection)
+    await page.goto(route.listPath)
+
+    if (!doc) {
+      await expect(page.getByText(route.emptyHeading, { exact: true })).toBeVisible()
+      continue
+    }
+
+    const row = page.locator('article').filter({ hasText: doc.title })
+    await row.getByRole('link', { name: new RegExp(route.primaryLabel, 'i') }).click()
+
+    const detailPath = route.path(doc.slug)
+    expect(new URL(page.url()).pathname).toBe(detailPath)
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(doc.title)
+
+    const expectedCanonical =
+      route.collection === 'posts' && doc.canonicalUrl
+        ? new URL(doc.canonicalUrl).toString()
+        : new URL(detailPath, 'https://ivmz.ivrm.jp').toString()
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute('href', expectedCanonical)
+    await expect(page.locator('meta[property="og:title"]')).toHaveAttribute(
+      'content',
+      `${doc.title} | mizzz`,
+    )
+
+    const direct = await page.goto(detailPath)
+    expect(direct?.ok(), detailPath).toBe(true)
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(doc.title)
+
+    const reload = await page.reload()
+    expect(reload?.ok(), `${detailPath} reload`).toBe(true)
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText(doc.title)
+  }
+})
+
+test('returns the same non-leaking 404 for unknown dynamic slugs', async ({ page }) => {
+  for (const route of ['/works', '/blog', '/news']) {
+    const response = await page.goto(`${route}/__ivmz-definitely-not-published__`)
+    expect(response?.status(), route).toBe(404)
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Signal not found.')
+    await expect(page.getByText(/draftの存在有無も公開routeからは区別しません/)).toBeVisible()
+  }
+})
+
+test('keeps a representative dynamic route overflow-free at every supported width', async ({
+  page,
+  request,
+}) => {
+  const work = await firstPublishedDoc(request, 'works')
+  const path = work ? `/works/${encodeURIComponent(work.slug)}` : '/works/__ivmz-responsive-404__'
+
+  for (const width of responsiveWidths) {
+    await page.setViewportSize({ width, height: 900 })
+    await page.goto(path)
+    const dimensions = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    expect(dimensions.scrollWidth, `${path} overflow at ${width}px`).toBeLessThanOrEqual(
+      dimensions.clientWidth + 1,
+    )
+  }
+})
+
+test('adds published internal detail routes to sitemap without indexing external-canonical posts', async ({
+  request,
+}) => {
+  const response = await request.get('/sitemap.xml')
+  expect(response.ok()).toBe(true)
+  const xml = await response.text()
+
+  for (const route of detailRoutes) {
+    const doc = await firstPublishedDoc(request, route.collection)
+    if (!doc) continue
+
+    const internalUrl = new URL(route.path(doc.slug), 'https://ivmz.ivrm.jp').toString()
+    if (route.collection === 'posts' && doc.canonicalUrl && new URL(doc.canonicalUrl).toString() !== internalUrl) {
+      expect(xml).not.toContain(`<loc>${internalUrl}</loc>`)
+    } else {
+      expect(xml).toContain(`<loc>${internalUrl}</loc>`)
+    }
+  }
+})

--- a/tests/e2e/dynamic-routes.spec.ts
+++ b/tests/e2e/dynamic-routes.spec.ts
@@ -120,7 +120,11 @@ test('adds published internal detail routes to sitemap without indexing external
     if (!doc) continue
 
     const internalUrl = new URL(route.path(doc.slug), 'https://ivmz.ivrm.jp').toString()
-    if (route.collection === 'posts' && doc.canonicalUrl && new URL(doc.canonicalUrl).toString() !== internalUrl) {
+    if (
+      route.collection === 'posts' &&
+      doc.canonicalUrl &&
+      new URL(doc.canonicalUrl).toString() !== internalUrl
+    ) {
       expect(xml).not.toContain(`<loc>${internalUrl}</loc>`)
     } else {
       expect(xml).toContain(`<loc>${internalUrl}</loc>`)

--- a/tests/e2e/payload.spec.ts
+++ b/tests/e2e/payload.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type APIResponse } from '@playwright/test'
 
 const publicCollections = ['works', 'posts', 'news', 'schedule', 'social-links'] as const
+const draftEnabledCollections = ['works', 'posts', 'news'] as const
 
 async function responseDiagnostic(response: APIResponse) {
   const contentType = response.headers()['content-type'] ?? 'unknown'
@@ -30,6 +31,19 @@ test('公開Content collectionは匿名readできる', async ({ request }) => {
     expect(response.status(), `${collection}: ${diagnostic}`).toBe(200)
     const payload = JSON.parse(await response.body().then((body) => body.toString('utf8')))
     expect(Array.isArray(payload.docs), collection).toBe(true)
+  }
+})
+
+test('draft-enabled Contentは匿名queryでもdraftを返さない', async ({ request }) => {
+  for (const collection of draftEnabledCollections) {
+    const response = await request.get(
+      `/api/${collection}?where[_status][equals]=draft&limit=1&depth=0`,
+    )
+    const diagnostic = await responseDiagnostic(response)
+
+    expect(response.status(), `${collection}: ${diagnostic}`).toBe(200)
+    const payload = JSON.parse(await response.body().then((body) => body.toString('utf8')))
+    expect(payload.docs, collection).toEqual([])
   }
 })
 

--- a/tests/e2e/routes.spec.ts
+++ b/tests/e2e/routes.spec.ts
@@ -12,6 +12,8 @@ const routes = [
   '/legal/terms',
 ] as const
 
+const responsiveWidths = [320, 375, 390, 768, 1024, 1440] as const
+
 test('serves every static/list route directly and after reload', async ({ page }) => {
   for (const route of routes) {
     const response = await page.goto(route)
@@ -44,10 +46,10 @@ test('marks the current route in desktop and mobile navigation', async ({ page }
   await expect(worksLink).toHaveAttribute('aria-current', 'page')
 })
 
-test('keeps route pages overflow-free at representative widths', async ({ page }, testInfo) => {
+test('keeps route pages overflow-free at the supported widths', async ({ page }, testInfo) => {
   test.skip(testInfo.project.name !== 'chromium', 'Responsive route matrix runs in Chromium')
 
-  for (const width of [320, 768, 1440]) {
+  for (const width of responsiveWidths) {
     await page.setViewportSize({ width, height: 900 })
     for (const route of routes) {
       await page.goto(route)


### PR DESCRIPTION
## Summary

GitHub Issue #7 の次Phaseとして、Payload-backed dynamic detail routesを追加します。

- `/works/[slug]`
- `/blog/[slug]`
- `/news/[slug]`
- published-only detail query boundary
- unknown / draft / unpublishedの404統一
- list → detail navigation
- dynamic metadata / canonical / Open Graph
- external canonical Blogのduplicate-content回避
- dynamic sitemap
- responsive / accessibility / Payload security regression tests

## Payload query boundary

`src/lib/payload-content.ts` に以下を追加しています。

- `getPublishedWorkBySlug(slug)`
- `getPublishedPostBySlug(slug)`
- `getPublishedNewsBySlug(slug)`

各queryは `overrideAccess: false` / `draft: false` / exact slug / `_status = published` を維持し、見つからない場合は `null` を返します。React page/componentからPayload Local APIを直接呼びません。

## Detail route behavior

### Works

既存Content Modelの `title` / `summary` / `role` / `stack` / `projectStatus` / `highlights` / `caseStudy` / GitHub / live URLを利用します。

Galleryは現在 `maxDepth: 0` のprotected Media境界を維持し、detail routeで無理にMedia documentを展開しません。

### Blog

Postsのtitle / excerpt / body / category / tags / publishedAt / canonicalUrl / relatedWorksを利用します。

`canonicalUrl` が外部正本を指す場合、内部detail routeはsummary / taxonomy / stable navigation pageとして維持し、本文を重複掲載しません。metadata canonicalは外部URLへ向けます。内部canonicalの記事だけdynamic sitemapへ追加します。

### News

News本文を内部detail routeのPrimary contentとし、`externalUrl` はsecondary source linkとして分離します。

## 404 / security

- unknown slug: 404
- draft / unpublished: public queryで取得不可 → 同じ404
- 404画面ではdraftの存在有無を区別しません
- anonymous write denial / Users非公開 / `/admin` smokeを維持
- DB schema / migration / runtime credential / RLS / Production DNSは変更しません

## SEO

- content-specific title / description
- canonical
- Open Graph
- published internal detail URLsをsitemapへ追加
- external-canonical Blogは内部URLをsitemapから除外

## Tests

追加・強化:

- published detail query contract
- canonical URL resolution
- list → detail navigation
- direct navigation / reload / h1 / canonical / Open Graph
- unknown dynamic slug 404
- anonymous draft query denial
- dynamic sitemap behavior
- 320 / 375 / 390 / 768 / 1024 / 1440 overflow coverage

既存test / security assertionsは削除・skip・弱体化していません。

## Validation — exact HEAD

Validated HEAD: `0ee5be97b38ddb539552a7ee27e7ec6dd42c97ce`

### GitHub Actions CI

CI run #182: GREEN

- `pnpm install --frozen-lockfile`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm db:migrate`
- `pnpm generate:types`
- `pnpm generate:importmap`
- generated Payload artifact drift check
- `pnpm build`

### Netlify Deploy Preview

- Deploy Preview #11: READY
- exact commit: `0ee5be97b38ddb539552a7ee27e7ec6dd42c97ce`
- Next.js Server Handler: deployed
- Netlify Secret Scan: 159 files / 0 matches
- Payload public API preflight: GREEN
- Chromium / mobile WebKit / Payload security projects: GREEN as part of Full Playwright
- Full Playwright: 38 tests / 34 passed / 4 skipped / 0 failed

現在Preview DBのWorks / Posts / Newsが0件のため、published実データを必要とするdetail success-path E2Eは条件付きskipです。unknown slug 404、Payload access/security regression、static/list routes等の実行可能なremote checksはGREENです。Production/Preview DBへ検証用contentを自動投入する変更は行っていません。

## Scope guard

変更しません:

- Store / Stripe
- Contact backend
- member/account
- Production S3
- Production DNS
- multilingual
- Search full implementation
- RSS / Atom
- large WebGL scenes

## Merge policy

Draftで検証を進めます。CI / Netlify Deploy Preview / review gateがGREENでも、ユーザーの明示指示まではmergeしません。

Refs #7