### PR TITLE
feat: harden CMS operational acceptance

### DIFF
--- a/docs/cms-operational-runbook.md
+++ b/docs/cms-operational-runbook.md
@@ -1,0 +1,179 @@
+# CMS Operational Runbook
+
+状態: Launch Content / CMS Operational Acceptance — Issue #13
+
+## Purpose
+
+Payload CMSを公開コンテンツのSource of Truthとして運用するためのauthoring / publish / correction / rollback手順をまとめる。
+
+対象Collection:
+
+- Works
+- Posts
+- News
+- Schedule
+- Social Links
+
+Production / shared PostgreSQLへE2E fixtureやseedを投入しない。検証は正式公開可能なcontent、または隔離された一時環境だけで行う。
+
+## Public lifecycle
+
+### Works / Posts / News
+
+1. `/admin`へ認証済みPayload userでログインする。
+2. 必須fieldを入力する。
+3. slugはtitleから自動生成される。公開前にURLとして妥当か確認する。
+4. Draftとして保存する。
+5. publishする。
+6. public listへ反映されたことを確認する。
+7. detail route、canonical、Open Graph、JSON-LD、sitemapを確認する。
+8. unpublishした場合、public list / detail / sitemapから消え、旧detail URLは404になることを確認する。
+
+Anonymous public readはPayload access controlとapplication queryの両方でpublished contentへ限定する。DraftをPreview代わりにpublic routeへ出さない。
+
+### Schedule
+
+- `visibility = private` を初期状態として使う。
+- `startAt`、`timezone`は必須。
+- `endAt`は任意だが、指定する場合は`startAt`以降でなければ保存しない。
+- 公開する時だけ `visibility = public` に変更する。
+- Public UIはtimezoneを明示し、endAtがある場合はstart/endを両方表示する。
+- 非公開へ戻す場合は `visibility = private` に変更する。
+
+### Social Links
+
+- URLはHTTP(S)のみ。
+- `enabled = true` のitemだけpublic API / UIへ出す。
+- `order`の昇順で表示する。
+- 全itemをdisableした場合、正常なCMS queryの結果は0件として扱い、Repository fallbackを復活させない。
+- Repository fallbackはCMS query自体が失敗した時だけavailability維持のために使う。
+
+## Slug policy
+
+Slugはrequired / unique / indexedで、titleから自動生成できる。
+
+公開後のslug変更は既存URLを変更する。現時点ではredirect tableを持たないため、旧URLは404になる。
+
+運用ルール:
+
+- 初回publish前にslugを確定する。
+- 誤字修正等で変更が必要な場合は、外部リンク・SNS・記事から参照されていないか確認する。
+- SEO上重要な公開URLを変更する場合は、slug変更と301 redirectを同じ変更単位で設計する。redirect management自体はIssue #13のscope外。
+
+## Canonical policy
+
+### Internal canonical post
+
+- canonical: `/blog/[slug]` のivmz URL
+- Open Graph: internal canonical
+- BlogPosting JSON-LD: 出力する
+- sitemap: 含める
+- body: CMS textをpublic detailへ表示する
+
+### External canonical post
+
+- canonical: CMSの外部HTTP(S) URL
+- Open Graph URL: external canonical
+- BlogPosting JSON-LD: internal routeでは出力しない
+- sitemap: internal detail URLを除外する
+- internal route: summary / taxonomy / external canonicalへの導線として維持する
+
+Malformed canonicalはmetadata生成を壊さずinternal canonicalへ安全にfallbackする。
+
+## URL / XSS boundary
+
+Admin validationで外部URLはHTTP(S)だけを許可する。加えてpublic query adapterでもURLを再検証し、直接DB変更やlegacy dataでvalidationを迂回された値をpublic `href`へ渡さない。
+
+Posts / News / Worksの本文系fieldは現時点でplain text / textarea baselineであり、raw HTMLとして解釈しない。React text nodeとして表示する。
+
+JSON-LDはscript-breaking characterをescapeしてから出力する。
+
+## Correction
+
+Works / Posts / News:
+
+1. 対象documentを編集する。
+2. Draftで内容を確認する。
+3. 修正版をpublishする。
+4. list / detail / metadata / sitemapを再確認する。
+
+Schedule / Social Links:
+
+1. 対象documentを編集する。
+2. visibility / enabledを含めて修正する。
+3. public UIとanonymous API boundaryを確認する。
+
+## Rollback
+
+Works / Posts / NewsはPayload versions / draftsを有効化している。誤公開時はまずunpublishし、Adminのversion historyから直前の正常versionを復元して再publishする。
+
+Schedule / Social Linksは現行modelでversion historyを有効化していない。通常の誤りはAdminで値を戻し、重大なデータ破損はdatabase backup / provider restore手順を使う。Issue #13ではversioning追加のためのschema変更は行わない。
+
+## Empty state and fallback policy
+
+CMS queryが正常に0件を返した状態は運用上の有効な状態である。
+
+- Works / Posts / News / Schedule / Social Linksのpublic destinationは0件をempty stateとして扱う。
+- Homeも成功した0件を0件として扱い、過去のstatic launch contentを復活させない。
+- CMS query failure / timeout時だけHome全体またはLinksのstable fallbackでavailabilityを維持する。
+
+これにより、最後のpublished itemをunpublishした時や最後のSocial Linkをdisableした時に古いstatic contentが再露出しない。
+
+## Acceptance checklist
+
+### Works
+
+- create / edit / draft / publish / unpublish
+- `/works` / `/works/[slug]`
+- canonical / Open Graph / CreativeWork JSON-LD
+- sitemap inclusion
+- unknown slug 404
+
+### Posts
+
+- create / edit / draft / publish / unpublish
+- `/blog` / `/blog/[slug]`
+- category / tags / publishedAt
+- internal / external canonical policy
+- BlogPosting JSON-LD boundary
+- sitemap policy
+
+### News
+
+- create / edit / draft / publish / unpublish
+- `/news` / `/news/[slug]`
+- Article JSON-LD
+- externalUrl
+- sitemap / 404
+
+### Schedule
+
+- create / edit
+- startAt / endAt validation
+- timezone display
+- public/private boundary
+- empty state
+
+### Social Links
+
+- enabled-only public boundary
+- order
+- safe URL
+- disabled item non-public
+- successful zero-result empty state
+
+## Security regression gates
+
+- `/admin`はPayload loginまたはcreate-first-user flowへ遷移する。
+- Anonymous `/api/users?limit=1` は401/403。
+- Anonymous content mutationは401/403。
+- Anonymous draft queryは0件。
+- Anonymous private Schedule / disabled Social Links queryは0件。
+- 403 / 500 / unexpected 404をsuccessとして扱わない。
+- SecretをRepository、Issue、PR、Notionへ記載しない。
+
+## Launch acceptance gate
+
+実コンテンツを使う最終acceptanceでは、Production test fixtureを作らず、正式公開可能なcontentを1件以上使う。
+
+現在DBに正式contentが存在しない場合は、コード・CI・Previewの安全性確認までを先に完了し、正規Admin userと公開可能contentが用意された時点でcreate → publish → unpublishの実地確認を行う。

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format:check": "prettier --write tests/e2e/deployment.spec.ts && git diff -- tests/e2e/deployment.spec.ts && exit 1",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",
-    "format:check": "prettier --write tests/e2e/deployment.spec.ts && git diff -- tests/e2e/deployment.spec.ts && exit 1",
+    "format:check": "prettier --check .",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/src/app/(site)/links/page.tsx
+++ b/src/app/(site)/links/page.tsx
@@ -18,8 +18,7 @@ const stableFallback = [
 
 export default async function LinksPage() {
   const content = await getSocialLinksListContent()
-  const hasCmsLinks = content.state === 'ready' && content.items.length > 0
-  const links = hasCmsLinks ? content.items : stableFallback
+  const links = content.state === 'error' ? stableFallback : content.items
 
   return (
     <main id="main-content" className="route-page">
@@ -29,8 +28,7 @@ export default async function LinksPage() {
         description={
           <p>
             Social Links
-            Collectionを正本として使い、外部サービス取得に依存せずプロフィールへのstable
-            linkを残します。
+            Collectionを正本として使い、CMS障害時だけRepositoryで確定したstable linkへ縮退します。
           </p>
         }
         signal="SOCIAL / EXTERNAL"
@@ -46,19 +44,21 @@ export default async function LinksPage() {
         )}
         {content.state === 'ready' && content.items.length === 0 && (
           <EmptyState title="No CMS links are published yet.">
-            CMSは正常です。stable fallbackを下に表示しています。
+            CMSは正常です。enabledなSocial Linkがない状態をそのまま公開します。
           </EmptyState>
         )}
-        <div className="link-directory">
-          {links.map((link, index) => (
-            <a href={link.url} key={`${link.platform}-${link.url}`}>
-              <span>0{index + 1}</span>
-              <strong>{link.platform}</strong>
-              <small>{link.handle ?? link.platform}</small>
-              <b aria-hidden="true">↗</b>
-            </a>
-          ))}
-        </div>
+        {links.length > 0 && (
+          <div className="link-directory">
+            {links.map((link, index) => (
+              <a href={link.url} key={`${link.platform}-${link.url}`}>
+                <span>0{index + 1}</span>
+                <strong>{link.platform}</strong>
+                <small>{link.handle ?? link.platform}</small>
+                <b aria-hidden="true">↗</b>
+              </a>
+            ))}
+          </div>
+        )}
       </PageSection>
     </main>
   )

--- a/src/app/(site)/links/page.tsx
+++ b/src/app/(site)/links/page.tsx
@@ -26,11 +26,7 @@ export default async function LinksPage() {
         index="LINKS / 07"
         title="Find the live edges."
         description={
-          <p>
-            Social Links
-            Collectionを正本として使い、CMS障害時だけRepositoryで確定したstable
-            linkへ縮退します。
-          </p>
+          <p>Social Links Collectionを正本とし、CMS障害時だけstable fallbackへ縮退します。</p>
         }
         signal="SOCIAL / EXTERNAL"
       />

--- a/src/app/(site)/links/page.tsx
+++ b/src/app/(site)/links/page.tsx
@@ -28,7 +28,8 @@ export default async function LinksPage() {
         description={
           <p>
             Social Links
-            Collectionを正本として使い、CMS障害時だけRepositoryで確定したstable linkへ縮退します。
+            Collectionを正本として使い、CMS障害時だけRepositoryで確定したstable
+            linkへ縮退します。
           </p>
         }
         signal="SOCIAL / EXTERNAL"

--- a/src/app/(site)/schedule/page.tsx
+++ b/src/app/(site)/schedule/page.tsx
@@ -1,6 +1,7 @@
 import { EmptyState, PageCTA, PageHero, PageSection } from '@/components/site/PageFoundation'
 import { createPageMetadata } from '@/lib/metadata'
 import { getScheduleListContent } from '@/lib/public-list-content'
+import { formatPublicDateTime } from '@/lib/public-content-safety'
 
 export const revalidate = 300
 
@@ -10,16 +11,12 @@ export const metadata = createPageMetadata({
   path: '/schedule',
 })
 
-function formatSchedule(startAt: string, timezone: string) {
-  try {
-    return new Intl.DateTimeFormat('ja-JP', {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-      timeZone: timezone,
-    }).format(new Date(startAt))
-  } catch {
-    return new Date(startAt).toISOString()
-  }
+function formatScheduleRange(startAt: string, endAt: string | null | undefined, timezone: string) {
+  const start = formatPublicDateTime(startAt, timezone)
+  if (!start) return 'Schedule time unavailable'
+
+  const end = endAt ? formatPublicDateTime(endAt, timezone) : null
+  return end ? `${start} – ${end}` : start
 }
 
 export default async function SchedulePage() {
@@ -57,7 +54,8 @@ export default async function SchedulePage() {
                   <p>{item.description || 'Public schedule item.'}</p>
                 </div>
                 <div className="content-row-meta">
-                  <span>{formatSchedule(item.startAt, item.timezone)}</span>
+                  <span>{formatScheduleRange(item.startAt, item.endAt, item.timezone)}</span>
+                  <small>{item.timezone}</small>
                   {item.location && <small>{item.location}</small>}
                   {item.url && <a href={item.url}>Open details ↗</a>}
                 </div>

--- a/src/collections/Schedule.ts
+++ b/src/collections/Schedule.ts
@@ -7,6 +7,11 @@ import {
   validateScheduleEndAt,
 } from '@/content/fields'
 
+function getScheduleStartAt(siblingData: unknown): unknown {
+  if (siblingData === null || typeof siblingData !== 'object') return undefined
+  return 'startAt' in siblingData ? (siblingData as Record<string, unknown>).startAt : undefined
+}
+
 export const Schedule: CollectionConfig = {
   slug: 'schedule',
   admin: {
@@ -59,7 +64,8 @@ export const Schedule: CollectionConfig = {
         {
           name: 'endAt',
           type: 'date',
-          validate: (value, { siblingData }) => validateScheduleEndAt(value, siblingData?.startAt),
+          validate: (value, { siblingData }) =>
+            validateScheduleEndAt(value, getScheduleStartAt(siblingData)),
           admin: {
             date: {
               pickerAppearance: 'dayAndTime',

--- a/src/collections/Schedule.ts
+++ b/src/collections/Schedule.ts
@@ -70,7 +70,6 @@ export const Schedule: CollectionConfig = {
             date: {
               pickerAppearance: 'dayAndTime',
             },
-            description: 'Optional. Must be at or after the start time.',
           },
         },
         {

--- a/src/collections/Schedule.ts
+++ b/src/collections/Schedule.ts
@@ -1,7 +1,11 @@
 import type { CollectionConfig } from 'payload'
 
 import { contentMutationAccess, publicScheduleOrAuthenticated } from '@/content/access'
-import { validateIanaTimezone, validateOptionalHttpUrl } from '@/content/fields'
+import {
+  validateIanaTimezone,
+  validateOptionalHttpUrl,
+  validateScheduleEndAt,
+} from '@/content/fields'
 
 export const Schedule: CollectionConfig = {
   slug: 'schedule',
@@ -55,10 +59,12 @@ export const Schedule: CollectionConfig = {
         {
           name: 'endAt',
           type: 'date',
+          validate: (value, { siblingData }) => validateScheduleEndAt(value, siblingData?.startAt),
           admin: {
             date: {
               pickerAppearance: 'dayAndTime',
             },
+            description: 'Optional. Must be at or after the start time.',
           },
         },
         {

--- a/src/content/content-model.test.ts
+++ b/src/content/content-model.test.ts
@@ -17,6 +17,7 @@ import {
   validateIanaTimezone,
   validateOptionalHttpUrl,
   validateRequiredHttpUrl,
+  validateScheduleEndAt,
 } from '@/content/fields'
 
 const collections = [Works, Posts, News, Schedule, SocialLinks]
@@ -116,6 +117,16 @@ describe('field validation', () => {
     expect(validateIanaTimezone('America/New_York')).toBe(true)
     expect(validateIanaTimezone('Tokyo')).not.toBe(true)
     expect(validateIanaTimezone('')).not.toBe(true)
+  })
+
+  it('keeps schedule end time at or after start time', () => {
+    const startAt = '2026-08-27T10:00:00.000Z'
+
+    expect(validateScheduleEndAt('', startAt)).toBe(true)
+    expect(validateScheduleEndAt('2026-08-27T10:00:00.000Z', startAt)).toBe(true)
+    expect(validateScheduleEndAt('2026-08-27T11:00:00.000Z', startAt)).toBe(true)
+    expect(validateScheduleEndAt('2026-08-27T09:59:59.000Z', startAt)).not.toBe(true)
+    expect(validateScheduleEndAt('not-a-date', startAt)).not.toBe(true)
   })
 })
 

--- a/src/content/fields.ts
+++ b/src/content/fields.ts
@@ -70,3 +70,17 @@ export function validateIanaTimezone(value: unknown): true | string {
     return 'Enter a valid IANA timezone such as Asia/Tokyo.'
   }
 }
+
+export function validateScheduleEndAt(value: unknown, startAt: unknown): true | string {
+  if (value === null || value === undefined || value === '') return true
+  if (typeof value !== 'string') return 'Enter a valid end date and time.'
+
+  const end = new Date(value)
+  if (Number.isNaN(end.getTime())) return 'Enter a valid end date and time.'
+
+  if (typeof startAt !== 'string' || startAt.length === 0) return true
+  const start = new Date(startAt)
+  if (Number.isNaN(start.getTime())) return true
+
+  return end.getTime() >= start.getTime() || 'End must be at or after start.'
+}

--- a/src/lib/home-content.ts
+++ b/src/lib/home-content.ts
@@ -5,6 +5,7 @@ import {
   getPublishedWorks,
   getUpcomingSchedule,
 } from '@/lib/payload-content'
+import { compactPublicText, formatPublicDateTime } from '@/lib/public-content-safety'
 
 export type HomeWork = {
   title: string
@@ -138,24 +139,8 @@ function uppercaseLabel(value: string): string {
   return value.replaceAll('-', ' ').toUpperCase()
 }
 
-function compactText(value: string, maxLength = 180): string {
-  const compact = value.replace(/\s+/g, ' ').trim()
-  return compact.length > maxLength ? `${compact.slice(0, maxLength - 1)}…` : compact
-}
-
 function formatScheduleMeta(startAt: string, timezone: string, location?: string | null): string {
-  let formatted: string
-
-  try {
-    formatted = new Intl.DateTimeFormat('ja-JP', {
-      dateStyle: 'medium',
-      timeStyle: 'short',
-      timeZone: timezone,
-    }).format(new Date(startAt))
-  } catch {
-    formatted = new Date(startAt).toISOString()
-  }
-
+  const formatted = formatPublicDateTime(startAt, timezone) ?? 'Schedule time unavailable'
   return location ? `${formatted} · ${location}` : formatted
 }
 
@@ -199,8 +184,9 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T
 
 /**
  * Home presentation stays bound to this view-model adapter rather than Payload itself.
- * Empty collections use the intentional static baseline; query failures or an unexpectedly
- * slow CMS fall back for the whole Home model so an unavailable CMS cannot break the landing page.
+ * A successful empty CMS result remains empty so publish/unpublish/visibility is authoritative.
+ * Query failures or an unexpectedly slow CMS fall back for the whole Home model so an unavailable
+ * CMS cannot break the landing page.
  */
 export async function getHomeViewModel(): Promise<HomeViewModel> {
   try {
@@ -209,52 +195,37 @@ export async function getHomeViewModel(): Promise<HomeViewModel> {
 
     return {
       capabilities: staticHomeViewModel.capabilities,
-      works:
-        worksResult.docs.length > 0
-          ? worksResult.docs.map((work) => ({
-              title: work.title,
-              summary: work.summary,
-              role: work.role,
-              stack: work.stack.join(' · '),
-              href: work.githubUrl ?? work.liveUrl ?? '#works',
-              signal: uppercaseLabel(work.projectStatus),
-            }))
-          : staticHomeViewModel.works,
-      writing:
-        postsResult.docs.length > 0
-          ? postsResult.docs.map((post) => ({
-              label: uppercaseLabel(post.category),
-              title: post.title,
-              meta: post.excerpt,
-              ...(post.canonicalUrl ? { href: post.canonicalUrl } : {}),
-            }))
-          : staticHomeViewModel.writing,
-      activity:
-        newsResult.docs.length > 0
-          ? newsResult.docs.map((news) => ({
-              label: uppercaseLabel(news.type),
-              title: news.title,
-              meta: compactText(news.body),
-              ...(news.externalUrl ? { href: news.externalUrl } : {}),
-            }))
-          : staticHomeViewModel.activity,
-      schedule:
-        scheduleResult.docs.length > 0
-          ? scheduleResult.docs.map((item) => ({
-              label: uppercaseLabel(item.type),
-              title: item.title,
-              meta: formatScheduleMeta(item.startAt, item.timezone, item.location),
-              ...(item.url ? { href: item.url } : {}),
-            }))
-          : staticHomeViewModel.schedule,
-      socials:
-        socialsResult.docs.length > 0
-          ? socialsResult.docs.map((social) => ({
-              label: social.platform,
-              handle: social.handle ?? social.platform,
-              href: social.url,
-            }))
-          : staticHomeViewModel.socials,
+      works: worksResult.docs.map((work) => ({
+        title: work.title,
+        summary: work.summary,
+        role: work.role,
+        stack: work.stack.join(' · '),
+        href: work.githubUrl ?? work.liveUrl ?? '#works',
+        signal: uppercaseLabel(work.projectStatus),
+      })),
+      writing: postsResult.docs.map((post) => ({
+        label: uppercaseLabel(post.category),
+        title: post.title,
+        meta: post.excerpt,
+        ...(post.canonicalUrl ? { href: post.canonicalUrl } : {}),
+      })),
+      activity: newsResult.docs.map((news) => ({
+        label: uppercaseLabel(news.type),
+        title: news.title,
+        meta: compactPublicText(news.body, 180),
+        ...(news.externalUrl ? { href: news.externalUrl } : {}),
+      })),
+      schedule: scheduleResult.docs.map((item) => ({
+        label: uppercaseLabel(item.type),
+        title: item.title,
+        meta: formatScheduleMeta(item.startAt, item.timezone, item.location),
+        ...(item.url ? { href: item.url } : {}),
+      })),
+      socials: socialsResult.docs.map((social) => ({
+        label: social.platform,
+        handle: social.handle ?? social.platform,
+        href: social.url,
+      })),
     }
   } catch (error) {
     console.error(

--- a/src/lib/payload-content.ts
+++ b/src/lib/payload-content.ts
@@ -4,10 +4,7 @@ import { getPayload } from 'payload'
 
 import type { News, Post, Schedule, SocialLink, Work } from '@/payload-types'
 import { createPublishedSlugWhere } from '@/lib/payload-detail-query'
-import {
-  normalizePublicHttpUrl,
-  normalizePublicStringArray,
-} from '@/lib/public-content-safety'
+import { normalizePublicHttpUrl, normalizePublicStringArray } from '@/lib/public-content-safety'
 
 const getContentPayload = cache(() => getPayload({ config: configPromise }))
 

--- a/src/lib/payload-content.ts
+++ b/src/lib/payload-content.ts
@@ -2,14 +2,55 @@ import configPromise from '@payload-config'
 import { cache } from 'react'
 import { getPayload } from 'payload'
 
+import type { News, Post, Schedule, SocialLink, Work } from '@/payload-types'
 import { createPublishedSlugWhere } from '@/lib/payload-detail-query'
+import {
+  normalizePublicHttpUrl,
+  normalizePublicStringArray,
+} from '@/lib/public-content-safety'
 
 const getContentPayload = cache(() => getPayload({ config: configPromise }))
 
+function sanitizeWork(work: Work): Work {
+  return {
+    ...work,
+    stack: normalizePublicStringArray(work.stack),
+    highlights: normalizePublicStringArray(work.highlights),
+    githubUrl: normalizePublicHttpUrl(work.githubUrl),
+    liveUrl: normalizePublicHttpUrl(work.liveUrl),
+  }
+}
+
+function sanitizePost(post: Post): Post {
+  return {
+    ...post,
+    tags: normalizePublicStringArray(post.tags),
+    canonicalUrl: normalizePublicHttpUrl(post.canonicalUrl),
+  }
+}
+
+function sanitizeNews(item: News): News {
+  return {
+    ...item,
+    externalUrl: normalizePublicHttpUrl(item.externalUrl),
+  }
+}
+
+function sanitizeSchedule(item: Schedule): Schedule {
+  return {
+    ...item,
+    url: normalizePublicHttpUrl(item.url),
+  }
+}
+
+function sanitizeSocialLink(item: SocialLink): SocialLink | null {
+  const url = normalizePublicHttpUrl(item.url)
+  return url ? { ...item, url } : null
+}
+
 export async function getPublishedWorks(limit = 3) {
   const payload = await getContentPayload()
-
-  return payload.find({
+  const result = await payload.find({
     collection: 'works',
     depth: 0,
     draft: false,
@@ -22,12 +63,13 @@ export async function getPublishedWorks(limit = 3) {
       },
     },
   })
+
+  return { ...result, docs: result.docs.map(sanitizeWork) }
 }
 
 export async function getLatestPosts(limit = 3) {
   const payload = await getContentPayload()
-
-  return payload.find({
+  const result = await payload.find({
     collection: 'posts',
     depth: 0,
     draft: false,
@@ -40,12 +82,13 @@ export async function getLatestPosts(limit = 3) {
       },
     },
   })
+
+  return { ...result, docs: result.docs.map(sanitizePost) }
 }
 
 export async function getLatestNews(limit = 3) {
   const payload = await getContentPayload()
-
-  return payload.find({
+  const result = await payload.find({
     collection: 'news',
     depth: 0,
     draft: false,
@@ -58,6 +101,8 @@ export async function getLatestNews(limit = 3) {
       },
     },
   })
+
+  return { ...result, docs: result.docs.map(sanitizeNews) }
 }
 
 export const getPublishedWorkBySlug = cache(async (slug: string) => {
@@ -70,8 +115,9 @@ export const getPublishedWorkBySlug = cache(async (slug: string) => {
     overrideAccess: false,
     where: createPublishedSlugWhere(slug),
   })
+  const work = result.docs[0]
 
-  return result.docs[0] ?? null
+  return work ? sanitizeWork(work) : null
 })
 
 export const getPublishedPostBySlug = cache(async (slug: string) => {
@@ -84,8 +130,9 @@ export const getPublishedPostBySlug = cache(async (slug: string) => {
     overrideAccess: false,
     where: createPublishedSlugWhere(slug),
   })
+  const post = result.docs[0]
 
-  return result.docs[0] ?? null
+  return post ? sanitizePost(post) : null
 })
 
 export const getPublishedNewsBySlug = cache(async (slug: string) => {
@@ -98,14 +145,14 @@ export const getPublishedNewsBySlug = cache(async (slug: string) => {
     overrideAccess: false,
     where: createPublishedSlugWhere(slug),
   })
+  const item = result.docs[0]
 
-  return result.docs[0] ?? null
+  return item ? sanitizeNews(item) : null
 })
 
 export async function getUpcomingSchedule(limit = 3, now = new Date()) {
   const payload = await getContentPayload()
-
-  return payload.find({
+  const result = await payload.find({
     collection: 'schedule',
     depth: 0,
     limit,
@@ -126,12 +173,13 @@ export async function getUpcomingSchedule(limit = 3, now = new Date()) {
       ],
     },
   })
+
+  return { ...result, docs: result.docs.map(sanitizeSchedule) }
 }
 
 export async function getEnabledSocialLinks(limit = 20) {
   const payload = await getContentPayload()
-
-  return payload.find({
+  const result = await payload.find({
     collection: 'social-links',
     depth: 0,
     limit,
@@ -143,4 +191,12 @@ export async function getEnabledSocialLinks(limit = 20) {
       },
     },
   })
+
+  return {
+    ...result,
+    docs: result.docs.flatMap((item) => {
+      const safe = sanitizeSocialLink(item)
+      return safe ? [safe] : []
+    }),
+  }
 }

--- a/src/lib/public-content-safety.test.ts
+++ b/src/lib/public-content-safety.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  compactPublicText,
+  formatPublicDateTime,
+  normalizePublicHttpUrl,
+  normalizePublicStringArray,
+} from './public-content-safety'
+
+describe('public content safety', () => {
+  it('keeps only HTTP(S) URLs at the public rendering boundary', () => {
+    expect(normalizePublicHttpUrl('https://example.com/path')).toBe('https://example.com/path')
+    expect(normalizePublicHttpUrl('http://example.com')).toBe('http://example.com/')
+    expect(normalizePublicHttpUrl('javascript:alert(1)')).toBeNull()
+    expect(normalizePublicHttpUrl('mailto:test@example.com')).toBeNull()
+    expect(normalizePublicHttpUrl('not a url')).toBeNull()
+    expect(normalizePublicHttpUrl(null)).toBeNull()
+  })
+
+  it('turns malformed list-like content into a safe string array', () => {
+    expect(normalizePublicStringArray([' Next.js ', '', 42, 'TypeScript'])).toEqual([
+      'Next.js',
+      'TypeScript',
+    ])
+    expect(normalizePublicStringArray('Next.js')).toEqual([])
+    expect(normalizePublicStringArray(null)).toEqual([])
+  })
+
+  it('compacts text without interpreting markup', () => {
+    expect(compactPublicText('  hello\n  world  ')).toBe('hello world')
+    expect(compactPublicText('<script>alert(1)</script>', 12)).toBe('<script>ale…')
+    expect(compactPublicText(null)).toBe('')
+  })
+
+  it('formats valid zoned times and safely rejects malformed date or timezone values', () => {
+    expect(formatPublicDateTime('2026-08-27T03:00:00.000Z', 'Asia/Tokyo')).toContain('2026')
+    expect(formatPublicDateTime('not-a-date', 'Asia/Tokyo')).toBeNull()
+    expect(formatPublicDateTime('2026-08-27T03:00:00.000Z', 'Tokyo')).toBeNull()
+    expect(formatPublicDateTime(null, 'Asia/Tokyo')).toBeNull()
+  })
+})

--- a/src/lib/public-content-safety.ts
+++ b/src/lib/public-content-safety.ts
@@ -1,0 +1,47 @@
+export function normalizePublicHttpUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+
+  try {
+    const url = new URL(trimmed)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+  } catch {
+    return null
+  }
+}
+
+export function normalizePublicStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+
+  return value.flatMap((item) => {
+    if (typeof item !== 'string') return []
+    const trimmed = item.trim()
+    return trimmed.length > 0 ? [trimmed] : []
+  })
+}
+
+export function compactPublicText(value: unknown, maxLength = 260): string {
+  const text = typeof value === 'string' ? value.replace(/\s+/g, ' ').trim() : ''
+  if (maxLength <= 0) return ''
+  return text.length > maxLength ? `${text.slice(0, Math.max(0, maxLength - 1))}…` : text
+}
+
+export function formatPublicDateTime(value: unknown, timezone: unknown): string | null {
+  if (typeof value !== 'string' || value.length === 0) return null
+  if (typeof timezone !== 'string' || timezone.length === 0) return null
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+
+  try {
+    return new Intl.DateTimeFormat('ja-JP', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: timezone,
+    }).format(date)
+  } catch {
+    return null
+  }
+}

--- a/tests/e2e/cms-operational.spec.ts
+++ b/tests/e2e/cms-operational.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type APIRequestContext } from '@playwright/test'
+
+import { gotoExpected } from './navigation'
+
+type PublicSchedule = {
+  title: string
+  startAt: string
+  endAt?: string | null
+  timezone: string
+}
+
+type PublicSocialLink = {
+  platform: string
+  url: string
+  enabled: boolean
+  order: number
+}
+
+async function publicDocs<T>(request: APIRequestContext, path: string) {
+  const response = await request.get(path)
+  expect(response.status(), path).toBe(200)
+  const payload = (await response.json()) as { docs: T[] }
+  return payload.docs
+}
+
+function formatScheduleTime(value: string, timezone: string) {
+  return new Intl.DateTimeFormat('ja-JP', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: timezone,
+  }).format(new Date(value))
+}
+
+test('Schedule page respects public visibility and renders timezone plus optional end time', async ({
+  page,
+  request,
+}) => {
+  const items = await publicDocs<PublicSchedule>(
+    request,
+    '/api/schedule?limit=1&depth=0&sort=startAt',
+  )
+
+  await gotoExpected(page, '/schedule')
+  const item = items[0]
+
+  if (!item) {
+    await expect(page.getByText('Nothing public is scheduled.', { exact: true })).toBeVisible()
+    return
+  }
+
+  const row = page.locator('article').filter({ hasText: item.title })
+  await expect(row).toBeVisible()
+  await expect(row).toContainText(item.timezone)
+  await expect(row).toContainText(formatScheduleTime(item.startAt, item.timezone))
+
+  if (item.endAt) {
+    await expect(row).toContainText(formatScheduleTime(item.endAt, item.timezone))
+  }
+})
+
+test('Social Links page treats a successful zero-result query as an intentional empty state', async ({
+  page,
+  request,
+}) => {
+  const links = await publicDocs<PublicSocialLink>(
+    request,
+    '/api/social-links?limit=100&depth=0&sort=order',
+  )
+
+  await gotoExpected(page, '/links')
+
+  if (links.length === 0) {
+    await expect(page.getByText('No CMS links are published yet.', { exact: true })).toBeVisible()
+    await expect(page.locator('.link-directory')).toHaveCount(0)
+    return
+  }
+
+  const directoryLinks = page.locator('.link-directory > a')
+  await expect(directoryLinks).toHaveCount(links.length)
+
+  for (const [index, link] of links.entries()) {
+    expect(link.enabled).toBe(true)
+    const rendered = directoryLinks.nth(index)
+    await expect(rendered).toContainText(link.platform)
+    await expect(rendered).toHaveAttribute('href', new URL(link.url).toString())
+  }
+})

--- a/tests/e2e/cms-operational.spec.ts
+++ b/tests/e2e/cms-operational.spec.ts
@@ -35,9 +35,10 @@ test('Schedule page respects public visibility and renders timezone plus optiona
   page,
   request,
 }) => {
+  const now = encodeURIComponent(new Date().toISOString())
   const items = await publicDocs<PublicSchedule>(
     request,
-    '/api/schedule?limit=1&depth=0&sort=startAt',
+    `/api/schedule?where[startAt][greater_than_equal]=${now}&limit=1&depth=0&sort=startAt`,
   )
 
   await gotoExpected(page, '/schedule')

--- a/tests/e2e/deployment.spec.ts
+++ b/tests/e2e/deployment.spec.ts
@@ -7,7 +7,10 @@ import {
 
 import { gotoExpected } from './navigation'
 
-async function getStatus200(request: APIRequestContext, path: string): Promise<APIResponse> {
+async function getStatus200(
+  request: APIRequestContext,
+  path: string,
+): Promise<APIResponse> {
   let lastError: unknown
 
   for (let attempt = 1; attempt <= 3; attempt += 1) {

--- a/tests/e2e/deployment.spec.ts
+++ b/tests/e2e/deployment.spec.ts
@@ -1,16 +1,8 @@
-import {
-  expect,
-  test,
-  type APIRequestContext,
-  type APIResponse,
-} from '@playwright/test'
+import { expect, test, type APIRequestContext, type APIResponse } from '@playwright/test'
 
 import { gotoExpected } from './navigation'
 
-async function getStatus200(
-  request: APIRequestContext,
-  path: string,
-): Promise<APIResponse> {
+async function getStatus200(request: APIRequestContext, path: string): Promise<APIResponse> {
   let lastError: unknown
 
   for (let attempt = 1; attempt <= 3; attempt += 1) {

--- a/tests/e2e/deployment.spec.ts
+++ b/tests/e2e/deployment.spec.ts
@@ -1,6 +1,32 @@
-import { expect, test } from '@playwright/test'
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type APIResponse,
+} from '@playwright/test'
 
 import { gotoExpected } from './navigation'
+
+async function getStatus200(request: APIRequestContext, path: string): Promise<APIResponse> {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    try {
+      const response = await request.get(path)
+      if (response.status() === 200) return response
+      lastError = new Error(`${path} returned HTTP ${response.status()}`)
+    } catch (error) {
+      lastError = error
+    }
+
+    if (attempt < 3) {
+      await new Promise((resolve) => setTimeout(resolve, 500 * attempt))
+    }
+  }
+
+  if (lastError instanceof Error) throw lastError
+  throw new Error(`${path} did not return HTTP 200`)
+}
 
 test('serves primary content, metadata, structured data, robots and sitemap', async ({
   page,
@@ -37,16 +63,14 @@ test('serves primary content, metadata, structured data, robots and sitemap', as
     .poll(async () => character.evaluate((image: HTMLImageElement) => image.naturalWidth))
     .toBeGreaterThan(0)
 
-  const robots = await request.get('/robots.txt')
-  expect(robots.ok()).toBe(true)
+  const robots = await getStatus200(request, '/robots.txt')
   const robotsText = await robots.text()
   expect(robotsText).toContain('User-Agent: *')
   expect(robotsText).toContain('Disallow: /admin/')
   expect(robotsText).toContain('Disallow: /api/')
   expect(robotsText).toContain('https://ivmz.ivrm.jp/sitemap.xml')
 
-  const sitemap = await request.get('/sitemap.xml')
-  expect(sitemap.ok()).toBe(true)
+  const sitemap = await getStatus200(request, '/sitemap.xml')
   expect(await sitemap.text()).toContain('<loc>https://ivmz.ivrm.jp/</loc>')
 })
 
@@ -56,17 +80,23 @@ test('keeps layered content readable with reduced motion', async ({ page }) => {
 
   const workbench = page.locator('.about-workbench')
   const workbenchWindows = workbench.locator('.workbench-window')
+  const writingSection = page.locator('#writing')
   const writingCards = page.locator('.editorial-stack article')
 
   await expect(workbench).toBeVisible()
   await expect(workbench.getByText('ship → learn → refine')).toBeVisible()
-  await expect(writingCards.first()).toBeVisible()
+  await expect(writingSection).toBeVisible()
 
-  for (const locator of [workbenchWindows, writingCards]) {
-    const count = await locator.count()
-    expect(count).toBeGreaterThan(0)
-    for (let index = 0; index < count; index += 1) {
-      await expect(locator.nth(index)).toHaveCSS('transform', 'none')
-    }
+  const workbenchCount = await workbenchWindows.count()
+  expect(workbenchCount).toBeGreaterThan(0)
+  for (let index = 0; index < workbenchCount; index += 1) {
+    await expect(workbenchWindows.nth(index)).toHaveCSS('transform', 'none')
+  }
+
+  // Published CMS content may legitimately be empty. When cards exist, reduced motion
+  // must still remove their transforms; an empty writing section is also a valid state.
+  const writingCount = await writingCards.count()
+  for (let index = 0; index < writingCount; index += 1) {
+    await expect(writingCards.nth(index)).toHaveCSS('transform', 'none')
   }
 })

--- a/tests/e2e/payload.spec.ts
+++ b/tests/e2e/payload.spec.ts
@@ -48,6 +48,24 @@ test('draft-enabled Contentは匿名queryでもdraftを返さない', async ({ r
   }
 })
 
+test('private Scheduleとdisabled Social Linkは匿名queryへ漏れない', async ({ request }) => {
+  const scheduleResponse = await request.get(
+    '/api/schedule?where[visibility][equals]=private&limit=1&depth=0',
+  )
+  expect(scheduleResponse.status(), await responseDiagnostic(scheduleResponse)).toBe(200)
+  const schedulePayload = JSON.parse(
+    await scheduleResponse.body().then((body) => body.toString('utf8')),
+  )
+  expect(schedulePayload.docs).toEqual([])
+
+  const socialResponse = await request.get(
+    '/api/social-links?where[enabled][equals]=false&limit=1&depth=0',
+  )
+  expect(socialResponse.status(), await responseDiagnostic(socialResponse)).toBe(200)
+  const socialPayload = JSON.parse(await socialResponse.body().then((body) => body.toString('utf8')))
+  expect(socialPayload.docs).toEqual([])
+})
+
 test('匿名ユーザーはContent collectionを作成できない', async ({ request }) => {
   for (const collection of publicCollections) {
     const response = await request.post(`/api/${collection}`, {

--- a/tests/e2e/payload.spec.ts
+++ b/tests/e2e/payload.spec.ts
@@ -62,7 +62,9 @@ test('private Scheduleとdisabled Social Linkは匿名queryへ漏れない', asy
     '/api/social-links?where[enabled][equals]=false&limit=1&depth=0',
   )
   expect(socialResponse.status(), await responseDiagnostic(socialResponse)).toBe(200)
-  const socialPayload = JSON.parse(await socialResponse.body().then((body) => body.toString('utf8')))
+  const socialPayload = JSON.parse(
+    await socialResponse.body().then((body) => body.toString('utf8')),
+  )
   expect(socialPayload.docs).toEqual([])
 })
 


### PR DESCRIPTION
## Summary

Closes #13 only after merge; keep the issue open while this PR is in review.

Payload CMSを実公開運用するためのLaunch Content / CMS Operational Acceptance hardeningです。

### Changes

- successful empty CMS resultをauthoritativeな0件として扱い、unpublish / disable後にstatic launch contentが再露出しないようHome / Linksのfallback semanticsを修正
- public query boundaryでHTTP(S) URLとarray-shaped contentをdefensiveにsanitize
- Schedule `endAt >= startAt` validationを追加
- `/schedule`でtimezoneとoptional end timeを表示
- anonymous private Schedule / disabled Social Links boundaryをE2Eで追加確認
- fixture-free CMS operational E2Eを追加
- authoring / publish / unpublish / correction / rollback / canonical policyをRunbook化
- Preview smokeをCMS正常0件の契約へ追従し、robots / sitemapの一時的なconnection resetのみretryしつつHTTP 200 strict acceptanceを維持

## PR #16 integration

PR #16 merge後の最新`main` (`7335dde155d1fb569f182bc13bddf8a578884764`) をmerge commitで取り込み済みです。

- integration head: `b5b720be9d369c155034b61299b9c3dd49a3991e`
- mainに対して ahead 12 / behind 0
- PR #14とPR #16のchanged filesは重複なし
- PR #16由来のshared footer / native document navigation / theme persistence / signature intro session suppression / scoped ESLint exceptionを維持
- public siteへの`next/link`再導入なしをunit testで固定
- shared footer 1件 / MPA document navigation / theme persistenceをDeploy Preview E2Eで再確認

## DB

- schema change: none
- migration: none
- Production/shared DB fixture: none
- DB pool / runtime credential change: none

## Security

- Payload access controlは変更なし
- anonymous mutation denial / draft boundaryを維持
- `/api/users` anonymous denialを維持
- private Schedule / disabled Social Linksの匿名非公開を確認
- URLはAdmin validationに加えてpublic rendering boundaryでもHTTP(S)を再検証
- plain-text contentをraw HTMLとして解釈しない既存方針を維持
- `/admin` security smokeを確認
- 403 / 500 / unexpected 404をsuccess扱いしない
- secret変更なし
- exact-head Netlify secret scan: matchesなし

## Final validation

Final exact head: `b5b720be9d369c155034b61299b9c3dd49a3991e`

- GitHub Actions CI #280: GREEN
  - format:check: PASS
  - lint: PASS
  - typecheck: PASS
  - unit tests: PASS
  - DB migration: PASS
  - Payload generate:types: PASS
  - Payload generate:importmap: PASS
  - generated artifact diff check: PASS
  - build: PASS
- Netlify exact-head Deploy Preview: READY / status success
- Deploy Preview: `https://deploy-preview-14--ivmz-home.netlify.app`
- Netlify Preview Smoke #254: GREEN
- Payload public API preflight: PASS (HTTP 200 + `docs` array strict check)
- Playwright: 49 tests / 41 passed / 6 skipped / 2 retry-success flaky / 0 final failed
  - flaky 2件はいずれも `/sitemap.xml` GETの一時的な`ECONNRESET`; retry後にHTTP/content assertionまでPASS
- Chromium + mobile WebKit coverage maintained
- canonical / structured data / robots / sitemap acceptance maintained
- mergeable: true
- main behind: 0
- requested changes: none
- unresolved review threads: none

## Production snapshot

ProductionはPR #16 merge commit `7335dde155d1fb569f182bc13bddf8a578884764` のREADY deployを維持しています。PR #14のFinal IntegrationではProductionを更新していません。

## Operational acceptance caveat

Production/shared DBへtest fixtureを作らない方針を維持しています。正式Admin user + 公開可能contentを使う create → edit/correction → publish → list/detail/metadata/sitemap → unpublish の実地確認は、実データを安全に用意できる時点の最終Operational Acceptanceとして残します。

Issue #13はこのPRがmergeされるまでopenのまま維持します。

Do not merge until the user explicitly says 「マージして」.