### PR TITLE
security: isolate Netlify preview database migrations

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,12 +1,12 @@
 [context.deploy-preview]
-  command = "node scripts/assert-preview-database.mjs && pnpm db:migrate && pnpm build"
+  command = "node scripts/assert-preview-database.mjs && PAYLOAD_DATABASE_POOL_MODE=session pnpm db:migrate && pnpm build"
 
 [context.deploy-preview.environment]
   PAYLOAD_PREVIEW_DATABASE_PROJECT_REF = "dzdgbkjmomvmexcbjyin"
   PAYLOAD_PRODUCTION_DATABASE_PROJECT_REF = "drazbrcqnjxjuygfxmlz"
 
 [context.branch-deploy]
-  command = "node scripts/assert-preview-database.mjs && pnpm db:migrate && pnpm build"
+  command = "node scripts/assert-preview-database.mjs && PAYLOAD_DATABASE_POOL_MODE=session pnpm db:migrate && pnpm build"
 
 [context.branch-deploy.environment]
   PAYLOAD_PREVIEW_DATABASE_PROJECT_REF = "dzdgbkjmomvmexcbjyin"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,13 @@
+[context.deploy-preview]
+  command = "node scripts/assert-preview-database.mjs && pnpm db:migrate && pnpm build"
+
+[context.deploy-preview.environment]
+  PAYLOAD_PREVIEW_DATABASE_PROJECT_REF = "dzdgbkjmomvmexcbjyin"
+  PAYLOAD_PRODUCTION_DATABASE_PROJECT_REF = "drazbrcqnjxjuygfxmlz"
+
+[context.branch-deploy]
+  command = "node scripts/assert-preview-database.mjs && pnpm db:migrate && pnpm build"
+
+[context.branch-deploy.environment]
+  PAYLOAD_PREVIEW_DATABASE_PROJECT_REF = "dzdgbkjmomvmexcbjyin"
+  PAYLOAD_PRODUCTION_DATABASE_PROJECT_REF = "drazbrcqnjxjuygfxmlz"

--- a/scripts/assert-preview-database.mjs
+++ b/scripts/assert-preview-database.mjs
@@ -1,0 +1,81 @@
+import { pathToFileURL } from 'node:url'
+
+const PREVIEW_CONTEXTS = new Set(['deploy-preview', 'branch-deploy'])
+
+function normalize(value) {
+  return value?.trim().toLowerCase() ?? ''
+}
+
+function containsProjectRef(url, projectRef) {
+  const expectedRef = normalize(projectRef)
+  const hostname = normalize(url.hostname)
+  const username = normalize(decodeURIComponent(url.username))
+
+  if (!expectedRef) return false
+
+  const isDirectConnection = hostname === `db.${expectedRef}.supabase.co`
+  const isPoolerConnection =
+    hostname.endsWith('.pooler.supabase.com') &&
+    (username === `postgres.${expectedRef}` || username.endsWith(`.${expectedRef}`))
+
+  return isDirectConnection || isPoolerConnection
+}
+
+export function assertPreviewDatabaseTarget(env = process.env) {
+  const context = env.CONTEXT?.trim()
+  const databaseUrl = env.DATABASE_URL?.trim()
+  const previewProjectRef = normalize(env.PAYLOAD_PREVIEW_DATABASE_PROJECT_REF)
+  const productionProjectRef = normalize(env.PAYLOAD_PRODUCTION_DATABASE_PROJECT_REF)
+
+  if (!PREVIEW_CONTEXTS.has(context)) {
+    throw new Error(`database migration is disabled for Netlify context: ${context || 'unset'}`)
+  }
+
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is not configured for the preview deploy context')
+  }
+
+  if (!/^[a-z0-9]+$/.test(previewProjectRef)) {
+    throw new Error('PAYLOAD_PREVIEW_DATABASE_PROJECT_REF is missing or invalid')
+  }
+
+  let parsedDatabaseUrl
+  try {
+    parsedDatabaseUrl = new URL(databaseUrl)
+  } catch {
+    throw new Error('DATABASE_URL is not a valid URL')
+  }
+
+  if (!['postgres:', 'postgresql:'].includes(parsedDatabaseUrl.protocol)) {
+    throw new Error('DATABASE_URL must use the postgres or postgresql protocol')
+  }
+
+  if (productionProjectRef && containsProjectRef(parsedDatabaseUrl, productionProjectRef)) {
+    throw new Error('refusing to migrate the Production Supabase project from a preview deploy')
+  }
+
+  if (!containsProjectRef(parsedDatabaseUrl, previewProjectRef)) {
+    throw new Error('DATABASE_URL does not target the configured Preview Supabase project')
+  }
+
+  return {
+    context,
+    projectRef: previewProjectRef,
+  }
+}
+
+const isExecutedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
+
+if (isExecutedDirectly) {
+  try {
+    const result = assertPreviewDatabaseTarget()
+    console.log(
+      `[preview-db-guard] verified ${result.context} targets Supabase project ${result.projectRef}`,
+    )
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown preview database guard error'
+    console.error(`[preview-db-guard] ${message}`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/assert-preview-database.test.mjs
+++ b/scripts/assert-preview-database.test.mjs
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertPreviewDatabaseTarget } from './assert-preview-database.mjs'
+
+const PREVIEW_REF = 'dzdgbkjmomvmexcbjyin'
+const PRODUCTION_REF = 'drazbrcqnjxjuygfxmlz'
+
+function baseEnv(overrides = {}) {
+  return {
+    CONTEXT: 'deploy-preview',
+    DATABASE_URL: `postgresql://postgres:secret@db.${PREVIEW_REF}.supabase.co:5432/postgres`,
+    PAYLOAD_PREVIEW_DATABASE_PROJECT_REF: PREVIEW_REF,
+    PAYLOAD_PRODUCTION_DATABASE_PROJECT_REF: PRODUCTION_REF,
+    ...overrides,
+  }
+}
+
+describe('assertPreviewDatabaseTarget', () => {
+  it('accepts the Preview project direct connection for deploy previews', () => {
+    expect(assertPreviewDatabaseTarget(baseEnv())).toEqual({
+      context: 'deploy-preview',
+      projectRef: PREVIEW_REF,
+    })
+  })
+
+  it('accepts the Preview project pooler connection for branch deploys', () => {
+    expect(
+      assertPreviewDatabaseTarget(
+        baseEnv({
+          CONTEXT: 'branch-deploy',
+          DATABASE_URL: `postgresql://postgres.${PREVIEW_REF}:secret@aws-1-ap-northeast-1.pooler.supabase.com:5432/postgres`,
+        }),
+      ),
+    ).toEqual({
+      context: 'branch-deploy',
+      projectRef: PREVIEW_REF,
+    })
+  })
+
+  it('rejects production context', () => {
+    expect(() => assertPreviewDatabaseTarget(baseEnv({ CONTEXT: 'production' }))).toThrow(
+      'database migration is disabled for Netlify context',
+    )
+  })
+
+  it('rejects the Production project even in a preview context', () => {
+    expect(() =>
+      assertPreviewDatabaseTarget(
+        baseEnv({
+          DATABASE_URL: `postgresql://postgres:secret@db.${PRODUCTION_REF}.supabase.co:5432/postgres`,
+        }),
+      ),
+    ).toThrow('refusing to migrate the Production Supabase project')
+  })
+
+  it('rejects another Supabase project', () => {
+    expect(() =>
+      assertPreviewDatabaseTarget(
+        baseEnv({
+          DATABASE_URL:
+            'postgresql://postgres:secret@db.aaaaaaaaaaaaaaaaaaaa.supabase.co:5432/postgres',
+        }),
+      ),
+    ).toThrow('DATABASE_URL does not target the configured Preview Supabase project')
+  })
+
+  it('rejects a missing database URL without exposing a secret', () => {
+    expect(() => assertPreviewDatabaseTarget(baseEnv({ DATABASE_URL: '' }))).toThrow(
+      'DATABASE_URL is not configured',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Closes #18

Netlify Deploy Preview / Branch Deployをdedicated Supabase Preview Project `ivmz-home-preview`へ安全に切り替え、Preview build前にRepositoryのPayload migrationsを適用する。

## Changes

- `netlify.toml`でDeploy Preview / Branch Deployのみ guarded migration → build を実行
- migration前にPreview DB target guardを実行
  - Netlify contextが`deploy-preview`または`branch-deploy`
  - `DATABASE_URL`が存在する
  - 接続先がPreview Project `dzdgbkjmomvmexcbjyin`
  - Production Project `drazbrcqnjxjuygfxmlz`を明示的に拒否
- Direct connection / Supabase Session / Transaction pooler形式のtarget識別に対応
- migration実行時だけ `PAYLOAD_DATABASE_POOL_MODE=session` を強制し、serverless runtime/build側のpool mode設定は変更しない
- connection stringそのものはログへ出力しない
- guard unit testsを追加

## Production impact

- Production contextのbuild command / `DATABASE_URL`は変更しない
- PreviewがProduction DBを指す場合はmigration前にfail closedする
- Production dataをPreviewへcloneしない
- Production DBへ本PR由来のmigration / fixtureは追加しない

## Operational configuration

- [x] Supabase dedicated Preview Project `ivmz-home-preview` 作成
- [x] project creation cost: `$0/month`
- [x] Netlify Deploy Preview `DATABASE_URL`をPreview DBへcontext分離
- [x] Preview DBをNetlify buildから`pnpm db:migrate`でbootstrap
- [x] Local environmentをmigration executorとして要求しない

Secret値はIssue / PR / source / CI logへ記載しない。

## Verification

Verified head: `7f2a53bf96c00612d613ce1fcea0ebe38f50a9d7`

- CI #308: **success**
  - format
  - lint
  - typecheck
  - unit
  - ephemeral PostgreSQL migration
  - generated types / importmap drift
  - Next production build
- Netlify Deploy Preview status: **success**
- Netlify Preview Smoke #280: **success**
  - Payload public API preflight: success
  - Playwright: **47 passed / 6 skipped / 53 total**
  - Chromium / mobile WebKit: success
  - Payload login rate-limit: **HTTP 429 confirmed at attempt 20**
- Preview Supabase DB read-only verification:
  - `ivmz_home`: **25 tables**
  - `ivmz_home.payload_migrations`: **2 records** matching Repository migration names
  - application content: empty / Production content copiedなし
- Production Supabase DB read-only verification:
  - existing migration names remain the original 2 only
  - Preview由来migration / fixture追加なし
- Review:
  - P1「preview migrationはSession semanticsを強制する」指摘を`7f2a53b`で修正
  - review thread resolved
  - requested changesなし

## RLS advisory follow-up

Supabase Advisorは`ivmz_home` table群のRLS disabledを警告するが、read-only privilege確認では`anon` / `authenticated` roleはいずれも`ivmz_home` schemaの`USAGE`を持たない。

本PRではPayloadのserver-side DB connection / Access Controlを壊す可能性があるためRLSを一括変更しない。別Issue #22でschema grants / exposed schema / Payload compatibilityを追跡する。

## Rollback

- PR revertでPreview-specific migration commandとguardを削除できる
- Netlify Deploy Preview / Branch Deployのcontext値を戻す場合もProduction contextは変更しない
- Preview DB bootstrap障害時はPreview Project側だけを復旧対象とし、Productionへrollback SQLを流さない
