### PR TITLE
feat(ops): add independent Netlify Profile Signal scheduler

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ S3_SECRET_ACCESS_KEY=
 
 # メールアダプター（このFoundation PRでは未設定）
 EMAIL_FROM=ivmz@ivrm.jp
+
+# Profile Signal external scheduler
+# Netlify Production secret only. Fine-grained GitHub token scoped to mizzz-ivr/mizzz-ivr with Contents: write.
+PROFILE_SIGNAL_GITHUB_TOKEN=

--- a/netlify.toml
+++ b/netlify.toml
@@ -16,4 +16,4 @@
   schedule = "*/5 * * * *"
 
 [functions."profile-signal-full-dispatch"]
-  schedule = "19 */3 * * *"
+  schedule = "9 */3 * * *"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,3 +11,9 @@
 [context.branch-deploy.environment]
   PAYLOAD_PREVIEW_DATABASE_PROJECT_REF = "dzdgbkjmomvmexcbjyin"
   PAYLOAD_PRODUCTION_DATABASE_PROJECT_REF = "drazbrcqnjxjuygfxmlz"
+
+[functions."profile-signal-stream-dispatch"]
+  schedule = "*/5 * * * *"
+
+[functions."profile-signal-full-dispatch"]
+  schedule = "19 */3 * * *"

--- a/netlify/functions/profile-signal-full-dispatch.mjs
+++ b/netlify/functions/profile-signal-full-dispatch.mjs
@@ -1,0 +1,36 @@
+const OWNER = "mizzz-ivr";
+const REPO = "mizzz-ivr";
+const EVENT_TYPE = "profile-signal-full";
+const API_VERSION = "2026-03-10";
+
+export default async () => {
+  const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("PROFILE_SIGNAL_GITHUB_TOKEN is not configured");
+  }
+
+  const response = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/dispatches`, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "ivmz-home-profile-signal-dispatcher",
+      "X-GitHub-Api-Version": API_VERSION,
+    },
+    body: JSON.stringify({
+      event_type: EVENT_TYPE,
+      client_payload: {
+        source: "netlify",
+        requested_at: new Date().toISOString(),
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Profile Signal full dispatch failed: HTTP ${response.status} ${body.slice(0, 500)}`);
+  }
+
+  console.log("Profile Signal full dispatch accepted by GitHub");
+};

--- a/netlify/functions/profile-signal-full-dispatch.mjs
+++ b/netlify/functions/profile-signal-full-dispatch.mjs
@@ -1,36 +1,35 @@
-const OWNER = "mizzz-ivr";
-const REPO = "mizzz-ivr";
-const EVENT_TYPE = "profile-signal-full";
-const API_VERSION = "2026-03-10";
+const OWNER = 'mizzz-ivr'
+const REPO = 'mizzz-ivr'
+const EVENT_TYPE = 'profile-signal-full'
+const API_VERSION = '2026-03-10'
 
 export default async () => {
-  const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN;
+  const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN
   if (!token) {
-    throw new Error("PROFILE_SIGNAL_GITHUB_TOKEN is not configured");
+    throw new Error('PROFILE_SIGNAL_GITHUB_TOKEN is not configured')
   }
 
   const response = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/dispatches`, {
-    method: "POST",
+    method: 'POST',
     headers: {
-      Accept: "application/vnd.github+json",
+      Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "User-Agent": "ivmz-home-profile-signal-dispatcher",
-      "X-GitHub-Api-Version": API_VERSION,
+      'Content-Type': 'application/json',
+      'User-Agent': 'ivmz-home-profile-signal-dispatcher',
+      'X-GitHub-Api-Version': API_VERSION,
     },
     body: JSON.stringify({
       event_type: EVENT_TYPE,
       client_payload: {
-        source: "netlify",
+        source: 'netlify',
         requested_at: new Date().toISOString(),
       },
     }),
-  });
+  })
 
   if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Profile Signal full dispatch failed: HTTP ${response.status} ${body.slice(0, 500)}`);
+    throw new Error(`Profile Signal full dispatch failed: HTTP ${response.status}`)
   }
 
-  console.log("Profile Signal full dispatch accepted by GitHub");
-};
+  console.log('Profile Signal full dispatch accepted by GitHub')
+}

--- a/netlify/functions/profile-signal-full-dispatch.mjs
+++ b/netlify/functions/profile-signal-full-dispatch.mjs
@@ -3,7 +3,7 @@ const REPO = 'mizzz-ivr'
 const EVENT_TYPE = 'profile-signal-full'
 const API_VERSION = '2026-03-10'
 
-export default async () => {
+const handler = async () => {
   const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN
   if (!token) {
     throw new Error('PROFILE_SIGNAL_GITHUB_TOKEN is not configured')
@@ -33,3 +33,5 @@ export default async () => {
 
   console.log('Profile Signal full dispatch accepted by GitHub')
 }
+
+export default handler

--- a/netlify/functions/profile-signal-stream-dispatch.mjs
+++ b/netlify/functions/profile-signal-stream-dispatch.mjs
@@ -1,0 +1,36 @@
+const OWNER = "mizzz-ivr";
+const REPO = "mizzz-ivr";
+const EVENT_TYPE = "profile-signal-stream";
+const API_VERSION = "2026-03-10";
+
+export default async () => {
+  const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN;
+  if (!token) {
+    throw new Error("PROFILE_SIGNAL_GITHUB_TOKEN is not configured");
+  }
+
+  const response = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/dispatches`, {
+    method: "POST",
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "ivmz-home-profile-signal-dispatcher",
+      "X-GitHub-Api-Version": API_VERSION,
+    },
+    body: JSON.stringify({
+      event_type: EVENT_TYPE,
+      client_payload: {
+        source: "netlify",
+        requested_at: new Date().toISOString(),
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Profile Signal stream dispatch failed: HTTP ${response.status} ${body.slice(0, 500)}`);
+  }
+
+  console.log("Profile Signal stream dispatch accepted by GitHub");
+};

--- a/netlify/functions/profile-signal-stream-dispatch.mjs
+++ b/netlify/functions/profile-signal-stream-dispatch.mjs
@@ -1,36 +1,35 @@
-const OWNER = "mizzz-ivr";
-const REPO = "mizzz-ivr";
-const EVENT_TYPE = "profile-signal-stream";
-const API_VERSION = "2026-03-10";
+const OWNER = 'mizzz-ivr'
+const REPO = 'mizzz-ivr'
+const EVENT_TYPE = 'profile-signal-stream'
+const API_VERSION = '2026-03-10'
 
 export default async () => {
-  const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN;
+  const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN
   if (!token) {
-    throw new Error("PROFILE_SIGNAL_GITHUB_TOKEN is not configured");
+    throw new Error('PROFILE_SIGNAL_GITHUB_TOKEN is not configured')
   }
 
   const response = await fetch(`https://api.github.com/repos/${OWNER}/${REPO}/dispatches`, {
-    method: "POST",
+    method: 'POST',
     headers: {
-      Accept: "application/vnd.github+json",
+      Accept: 'application/vnd.github+json',
       Authorization: `Bearer ${token}`,
-      "Content-Type": "application/json",
-      "User-Agent": "ivmz-home-profile-signal-dispatcher",
-      "X-GitHub-Api-Version": API_VERSION,
+      'Content-Type': 'application/json',
+      'User-Agent': 'ivmz-home-profile-signal-dispatcher',
+      'X-GitHub-Api-Version': API_VERSION,
     },
     body: JSON.stringify({
       event_type: EVENT_TYPE,
       client_payload: {
-        source: "netlify",
+        source: 'netlify',
         requested_at: new Date().toISOString(),
       },
     }),
-  });
+  })
 
   if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Profile Signal stream dispatch failed: HTTP ${response.status} ${body.slice(0, 500)}`);
+    throw new Error(`Profile Signal stream dispatch failed: HTTP ${response.status}`)
   }
 
-  console.log("Profile Signal stream dispatch accepted by GitHub");
-};
+  console.log('Profile Signal stream dispatch accepted by GitHub')
+}

--- a/netlify/functions/profile-signal-stream-dispatch.mjs
+++ b/netlify/functions/profile-signal-stream-dispatch.mjs
@@ -3,7 +3,7 @@ const REPO = 'mizzz-ivr'
 const EVENT_TYPE = 'profile-signal-stream'
 const API_VERSION = '2026-03-10'
 
-export default async () => {
+const handler = async () => {
   const token = process.env.PROFILE_SIGNAL_GITHUB_TOKEN
   if (!token) {
     throw new Error('PROFILE_SIGNAL_GITHUB_TOKEN is not configured')
@@ -33,3 +33,5 @@ export default async () => {
 
   console.log('Profile Signal stream dispatch accepted by GitHub')
 }
+
+export default handler


### PR DESCRIPTION
## Summary

Add Netlify Scheduled Functions that independently trigger Profile Signal refreshes in `mizzz-ivr/mizzz-ivr`.

## Schedule

- `profile-signal-stream-dispatch`: every 5 minutes
- `profile-signal-full-dispatch`: every 3 hours at minute 09

The full refresh is deliberately staggered from the existing GitHub-native full refresh at minute 19 during the migration period. These schedules run on Netlify rather than GitHub Actions, removing the shared GitHub scheduler failure domain.

## Security

- expects `PROFILE_SIGNAL_GITHUB_TOKEN` only from the Netlify runtime environment
- token is never committed
- missing token fails closed
- non-2xx errors report only HTTP status and do not log the GitHub response body
- recommended token: fine-grained, repository access limited to `mizzz-ivr/mizzz-ivr`, `Contents: write` only

## Dependency

Do not merge/deploy to production until the receiver PR is merged and the Netlify secret is configured:

- Receiver: https://github.com/mizzz-ivr/mizzz-ivr/pull/57 — merged
- Tracking: #25
- Profile tracking: https://github.com/mizzz-ivr/mizzz-ivr/issues/56

After external E2E acceptance, GitHub-native primary schedules should be demoted so the existing freshness fallback is the secondary scheduler rather than running duplicate primary refreshes.

Closes part of #25.