### PR TITLE
docs(security): align post-rollout production guardrails

### DIFF
--- a/docs/database-runtime.md
+++ b/docs/database-runtime.md
@@ -4,7 +4,19 @@
 
 `ivmz-home` はPayload CMSのPostgreSQL接続を `DATABASE_URL` の背後に維持しつつ、migrationとserverless runtimeで異なる接続特性を安全に扱う。
 
-Repository migrationとruntime credentialは引き続き既存方針を維持し、database passwordや完全なconnection stringをRepositoryへ記録しない。
+Database passwordや完全なconnection stringをRepository / Issue / PR / Notion / CI logへ記録しない。
+
+## Current environment topology
+
+| Context | Database | Migration connection | Runtime connection |
+| --- | --- | --- | --- |
+| Production | Supabase `ivrm-core` | explicit release gate | Netlify serverless transaction mode |
+| Deploy Preview | Supabase `ivmz-home-preview` | Netlify buildでsession mode | Netlify serverless transaction mode |
+| Branch Deploy | `ivmz-home-preview` | Netlify buildでsession mode | Netlify serverless transaction mode |
+| GitHub CI | ephemeral PostgreSQL 17 | normal PostgreSQL | test process |
+| Local | local/dev PostgreSQL | normal PostgreSQL | persistent process |
+
+Production dataをPreviewへcopyしない。
 
 ## Connection modes
 
@@ -14,60 +26,83 @@ Repository migration (`pnpm db:migrate`) はdirect connectionまたはSupabase S
 
 - direct PostgreSQL: `5432`
 - Supabase Session pooler: `5432`
-- application側で追加のpool上限を強制しない
+- application側でserverless向けpool上限を強制しない
 
-Migrationはsession-level behaviorや複数接続を必要とする可能性があるため、serverless向けのpool上限を適用しない。
+Migrationはsession-level behaviorや複数接続を必要とする可能性があるため、serverless transaction poolingへ自動変換しない。
+
+Deploy Preview / Branch Deploy migration commandでは `PAYLOAD_DATABASE_POOL_MODE=session` を明示し、runtime側のtransaction poolingと分離する。
 
 ### Netlify serverless runtime
 
-Netlify Functionsのような短命・水平スケールするruntimeではSupabase Transaction poolerを使用する。
+`src/lib/database-connection.ts` は次の優先順位でpool modeを解決する。
 
-Netlify側で次の非Secret環境変数を設定する。
+1. `PAYLOAD_DATABASE_POOL_MODE=session|transaction` が明示されていればその値を使う。
+2. 未設定でもNetlify Functions runtimeで `AWS_LAMBDA_FUNCTION_NAME` が存在する場合は `transaction` と判定する。
+3. それ以外はURLを変更しない。
 
-```text
-PAYLOAD_DATABASE_POOL_MODE=transaction
-```
-
-`src/lib/database-connection.ts` はこのmodeが明示された場合だけ、次の条件をすべて満たす `DATABASE_URL` をruntime用に変換する。
-
-- hostnameが `.pooler.supabase.com` で終わる
-- portがSession poolerの `5432`
-- `PAYLOAD_DATABASE_POOL_MODE=transaction`
-
-変換内容はportだけである。
+transaction mode時に、`DATABASE_URL` がSupabase Session pooler (`*.pooler.supabase.com:5432`) の場合だけportを変換する。
 
 ```text
 5432 -> 6543
 ```
 
-username / password / hostname / database / query parameterは変更しない。完全なconnection stringを別の環境変数へ複製しないため、credential rotation時の二重管理も避けられる。
+username / password / hostname / database / query parameterは変更しない。
 
-Transaction pooler使用時はPayload内部の`node-postgres` application poolを小さい固定上限 `max: 5` に制限する。Payload初期化が接続を保持している間も後続query用の接続枠を確保しつつ、各serverless instanceが過剰な接続を抱え込まない構成にする。`max: 1` は初期化用接続だけでpoolを使い切り、後続の`find()`等がpool待ちになるため使用しない。
+Transaction pooler利用時だけPayload内部の`node-postgres` poolを `max: 5` に制限する。`max: 1` はPayload初期化用接続でpoolを使い切る可能性があるため使用しない。
 
 ## Safety guards
 
-- `PAYLOAD_DATABASE_POOL_MODE` が未設定または `session` の場合、`DATABASE_URL` は一切変更しない
+- `PAYLOAD_DATABASE_POOL_MODE=session` の場合はtransaction portへ変換しない
 - Supabase pooler以外のhostnameは変更しない
-- 既に6543または別portのURLは変更しない
-- URL parseに失敗した場合は入力値をそのまま返し、credentialを書き換えない
-- GitHub Actions migrationではこのmodeを設定しない
-- DB schema / migration / role / password / RLS policyはこのpooling policyでは変更しない
+- Session pooler `5432`以外のportは変更しない
+- URL parseに失敗した場合は入力値をそのまま使う
+- username / password / hostname / database / query parameterを再生成しない
+- GitHub CI migrationでtransaction modeを強制しない
+- DB schema / migration / role / password / RLS policyはpooling helperでは変更しない
+- connection stringをdiagnostic logへ出さない
 
 ## Prepared statement compatibility
 
-Supabase Transaction poolerはnamed prepared statementsをサポートしない。現在のPayload PostgreSQL adapterはDrizzle ORM + `node-postgres` を使用しており、このRepositoryでは実Deploy PreviewのPayload REST/Admin smokeを必須gateとして互換性を検証する。
+Supabase Transaction poolerはnamed prepared statementsに制約がある。
 
-Payload / Drizzle / node-postgres更新時にnamed prepared statementの利用方法が変化した場合は、Transaction pooler compatibilityを再検証する。
+Payload / Drizzle / `node-postgres`の更新時は、real Deploy PreviewでPayload REST/Admin smokeを実行してcompatibilityを再確認する。
 
-## Rollout gate
+Dependency更新だけを理由にtransaction pooling compatibilityを推測で維持扱いにしない。
 
-1. Deploy Previewだけ `PAYLOAD_DATABASE_POOL_MODE=transaction` を有効化する
-2. Chromium / mobile WebKit / Payload security smokeを実Deploy Previewで完走する
-3. `/admin` がPayload login / first-user routeへ正常遷移することを確認する
-4. anonymous Users APIが401/403になることを確認する
-5. public Content API readが200になり、`docs`配列を返すことを確認する
-6. anonymous Content mutationが401/403になることを確認する
-7. GitHub CI migrationが従来どおりGREENであることを確認する
-8. Preview検証がGREENになった後だけProduction contextへ同じ非Secretmodeを設定する
+## Preview migration target guard
 
-HTTP 500の許容、security smokeのskip、認可期待値の緩和はしない。
+Issue #18 / PR #21でDeploy Preview / Branch Deploy migrationにfail-closed target guardを導入済み。
+
+- contextが`deploy-preview` / `branch-deploy`以外なら拒否
+- `DATABASE_URL`未設定なら拒否
+- Preview Supabase Project refと一致しなければ拒否
+- Production Project refは明示的に拒否
+- migration commandのみsession modeを強制
+- Production buildにはPreview migration commandを設定しない
+
+Repository `src/migrations/` をmigration Source of Truthとし、Supabase CLI migrationとの二重管理やmigration historyの手動INSERTを行わない。
+
+## Runtime acceptance
+
+fresh Deploy Previewでは最低限次を確認する。
+
+1. build中のPreview migration target guardが通る
+2. Payload public API preflight 200
+3. `/admin` login surfaceが正常
+4. anonymous Users APIが401/403
+5. public Content API readが200
+6. draft / versions / private dataがanonymousへ漏れない
+7. anonymous mutationが401/403
+8. Chromium / mobile WebKitがGREEN
+9. non-existent probe identityによるlogin rate limit 429
+10. secret scan 0 matches
+
+Remote GETの既知transient transport failureだけはshared E2E helperで最大1回retryする。HTTP 4xx/5xx、assertion failure、POST/PATCH/DELETE mutationはretryしない。
+
+## Production gate
+
+Production runtimeはGitHub `main` -> Netlify Git integrationのreviewed deployだけを使用する。
+
+Production migrationはbuildと切り離し、必要なschema migrationがある時だけbackup / migration review / rollbackを準備したrelease gateとして実行する。
+
+HTTP 500の許容、security smokeのskip、認可期待値の緩和でdeployを通さない。

--- a/docs/hosting.md
+++ b/docs/hosting.md
@@ -1,31 +1,28 @@
-# Hosting方針 — 2026-08-26
+# Hosting方針 — updated 2026-08-28
 
 ## 目的
 
-現在のDNS providerへapplicationを密結合せずにLaunch hostを決定する。`ivmz.ivrm.jp` のauthoritative DNSを将来CloudflareからAmazon Route 53へ移行しても、product codeを書き直さずに済む構成を維持する。
+現在のDNS providerへapplicationを密結合せず、Production / Preview / Localのsecurity boundaryを明示した上でLaunch hostを運用する。
+
+`ivmz.ivrm.jp` のauthoritative DNSを将来CloudflareからAmazon Route 53へ移行しても、product codeを書き直さずに済む構成を維持する。
 
 Personal Web PlatformのRepositoryは `mizzz-ivr/ivmz-home`。Identity / contact方針は `docs/identity-contact.md` を正とする。
 
-## Launch時のベスト案: Netlify
+## Current launch architecture
 
-現時点で適している理由:
-
-- NetlifyはNext.js App Router、SSR、ISR、React Server Components、Server Actions、response streaming、`next/after`、middleware、image optimizationを公式にサポートしている。
-- PayloadはNext.jsが動作する環境へdeploy可能であり、NetlifyとAWSも対象に含まれる。
-- Content/design中心の初期Phaseではplatform運用負荷を小さく保てる。
-- DNSを独立させられるため、将来authoritative DNSを変更してもrecordとvalidationの変更に留まり、application codeへ波及しない。
-
-推奨するLaunch構成:
+Launch hostはNetlifyを継続採用する。
 
 ```text
-Route/DNS（当面Cloudflare -> 将来Route 53）
+Cloudflare DNS
   -> Netlify Next.js runtime
-      -> PostgreSQL（provider-neutralなDATABASE_URL）
-      -> AWS S3 media
-      -> Email adapter
+      -> Payload CMS
+          -> Production: Supabase ivrm-core / schema ivmz_home
+          -> Preview: Supabase ivmz-home-preview / schema ivmz_home
+      -> durable media adapter（導入gateあり）
+      -> email adapter
 ```
 
-Canonical production host:
+Canonical Production:
 
 ```text
 https://ivmz.ivrm.jp
@@ -33,107 +30,185 @@ https://ivmz.ivrm.jp
 
 `mizzz.jp` はlegacy / old-link compatibilityとしてWeb trafficを `ivmz.ivrm.jp` へredirectする。
 
+## Why Netlify remains the launch host
+
+- Next.js App Router / SSR / RSC / Streaming / Server Actionsを既存構成のまま運用できる。
+- PayloadをNext.js runtimeへ統合した現在のarchitectureを維持できる。
+- GitHub PR -> Deploy Preview -> merge -> Productionのreview workflowを構築済み。
+- DNSをapplicationから独立させられる。
+- 小規模個人Platformとして、ECS等へ移すより運用負荷を抑えられる。
+
+Provider portabilityは維持し、Netlify固有機能はdeployment/security adapter境界へ閉じ込める。
+
+## Production deployment path
+
+Production publishの正規経路は次の通り。
+
+```text
+Issue
+  -> branch
+  -> implementation
+  -> CI
+  -> Draft PR
+  -> Netlify Deploy Preview
+  -> Preview Smoke / review
+  -> merge to GitHub main
+  -> Netlify Git integration
+  -> Production
+```
+
+ProductionはGitHub `main`をSource of Truthとする。
+
+Netlifyの **Enforce Git-based deployments** を有効化し、CLI / API / MCP / Deploy PreviewからProductionへの直接publishを禁止する。設定方法とacceptanceは `docs/netlify-bootstrap.md` を参照する。
+
 ## Payload + PostgreSQL deployment gate
 
 Payload `3.88.0` は `@payloadcms/db-postgres` と `DATABASE_URL` を使用する。Payload管理tableはPostgreSQL schema `ivmz_home` に分離する。
 
-Foundationで必要なruntime variable:
+必要なruntime variable:
 
 - `DATABASE_URL`
 - `PAYLOAD_SECRET`
 - `PAYLOAD_ALLOWED_ORIGINS`
-- hosting環境で明示的なPayload originが必要な場合は `PAYLOAD_PUBLIC_SERVER_URL`
+- 必要な環境だけ `PAYLOAD_PUBLIC_SERVER_URL`
 
-`src/migrations` 配下のRepository migrationを正本とする。Deployment sequenceは意図的に分離する。
+`src/migrations` 配下のRepository migrationをschema migrationのSource of Truthとする。
 
-1. `pnpm install --frozen-lockfile` でinstallする
-2. 対象databaseへ明示的なgateとして `pnpm db:migrate` を適用する
-3. Review済みの同一revisionをdeployする
-4. `/admin`、Payload REST API authorization、既存public smoke testを検証する
+Production sequence:
 
-`pnpm build` からproduction migrationを**自動実行しない**。Netlify buildやretryのたびに暗黙のschema変更が発生する設計を避けるためである。
+1. Repository migrationをreviewする。
+2. 対象Production DBを明示して必要なmigrationだけを適用する。
+3. review済み同一revisionを`main`へmergeする。
+4. Netlify Git integrationでProduction deployする。
+5. exact commit / `/admin` / Payload REST authorization / public smokeを確認する。
 
-CIではGitHub Actions上にephemeral PostgreSQL 17 serviceを起動し、Next.js build前に同一のRepository migrationを適用する。
+`pnpm build`からProduction migrationを自動実行しない。build retryやhosting retryをDB schema change triggerにしない。
 
-## Preview database境界
+CIではGitHub Actions上にephemeral PostgreSQL 17 serviceを起動し、Next.js build前にRepository migrationを適用する。
 
-FoundationのDeploy Previewでは、既存PostgreSQL clusterを利用する場合もapplication専用の `ivmz_home` schemaとruntime role `ivmz_home_app` で分離する。
+## Environment database matrix
 
-- Payload側は `schemaName: 'ivmz_home'` を使用する
-- `public` schemaへPayload tableを作成しない
-- Preview用runtime roleへsuperuser / CREATEDB / CREATEROLEを付与しない
-- Repository migrationとPayload migration stateを一致させる
-- Previewで使用する接続先はProduction providerの恒久決定とはみなさない
-- `DATABASE_URL` はNetlify secretとして管理し、RepositoryやNotionへcredentialを記録しない
+| Context | Project / DB | Schema | Data | Migration |
+| --- | --- | --- | --- | --- |
+| Production | Supabase `ivrm-core` | `ivmz_home` | Production | 明示Production gate |
+| Netlify Deploy Preview | Supabase `ivmz-home-preview` | `ivmz_home` | Production dataなし | guarded Netlify build |
+| Netlify Branch Deploy | Supabase `ivmz-home-preview` | `ivmz_home` | Production dataなし | guarded Netlify build |
+| GitHub CI | ephemeral PostgreSQL 17 | `ivmz_home` | test only | CI build前 |
+| Local / Dev | local/dev PostgreSQL | `ivmz_home` | local only | developer controlled |
+
+Production dataをPreviewへcopyしない。
+
+## Preview database isolation
+
+Issue #18 / PR #21でdedicated Supabase Preview project `ivmz-home-preview` を導入済み。
+
+### Guardrails
+
+- Preview / Branchだけmigrationを許可する。
+- target guardがPreview Project refと一致しない場合はfail closed。
+- Production Project refは明示的に拒否する。
+- migration時だけsession poolingを使う。
+- runtime側のpool modeとmigration connectionを分離する。
+- connection stringやcredentialをlogしない。
+- Preview DBへProduction fixture / Production user / Production contentをcopyしない。
+
+Preview projectはapplication lifecycleの検証環境であり、Productionのbackupやreplicaとして扱わない。
+
+## PAYLOAD_SECRET environment boundary
+
+2026-08-28にNetlify contextを分離した。
+
+| Context | Secret policy |
+| --- | --- |
+| Production | Production専用。現行値は準備なしにrotationしない |
+| Deploy Preview | Productionと異なるPreview専用secret |
+| Branch Deploy | Production / Preview双方と異なるBranch専用secret |
+| Local / CI | Production secretを使用しない |
+
+Production secret rotationはrollback用旧secretをNetlify外のapproved secret managerからrecoverできることを確認してから実行する。
+
+詳細は `docs/payload-security-operations.md` を参照する。
+
+## Supabase / Payload access boundary
+
+`ivmz_home` はSupabase client API用schemaではなく、Payload server-side PostgreSQL schemaとして扱う。
+
+Production read-only verification baseline:
+
+- schema owner: `ivmz_home_app`
+- `anon` / `authenticated` / `service_role`: schema USAGEなし
+- 同client roles: Payload-managed tablesへのSELECT / mutationなし
+- `ivmz_home_app`: required read/writeあり、non-superuser、`BYPASSRLS=false`
+
+Preview:
+
+- schema owner: `postgres`
+- `anon` / `authenticated` / `service_role`: schema USAGEなし、Payload tables read/writeなし
+
+Payload-managed 25 tablesは現時点でRLS disabled。
+
+Supabase advisorのRLS disabled warningだけを理由に一括RLSを導入しない。client role grantsを与えないこととPayload Access Controlをauthorization boundaryとして維持する。
+
+Data API exposed schema / schema grants / application roleを変更する場合はRLS posture reviewを再実施する。
+
+## Security headers / CSP
+
+全route baseline:
+
+- HSTS
+- X-Content-Type-Options
+- Referrer-Policy
+- Permissions-Policy
+- X-Frame-Options
+- CSP Report-Only
+- Next.js powered-by removal
+
+CSPはreal violation observationなしにenforceしない。Payload Admin / Next.js inline assetsを含め、必要sourceを確認した後に独立PRでenforce readinessを判断する。
 
 ## Media storage gate
 
-Foundation PRではAWS resourceを作成しない。
+- local developmentではPayload Mediaをlocal storageへ保存できる。
+- Productionではdurable storage adapter導入前にMedia mutationを安易に解放しない。
+- Production durable storageの第一候補はAWS S3。
+- S3導入時はIAMを最小権限にし、恒常resourceはTerraform等で再現可能にする。
+- PreviewとProductionのobject storage credentialを共有しない。
 
-- local developmentではPayload Mediaを `media/` へ保存できる
-- productionではlocal storageを無効化する
-- durable storage adapterを設定するまではproductionのMedia create/update/deleteを許可しない
-- Production用adapterの第一候補はAWS S3とする
-- S3導入時は恒常的なAWS resourceとIAM policyをTerraformで管理する
+## AWS future option
 
-Foundationをcompileさせるだけの目的で `netlify.toml`、Netlify database API、Cloudflare R2 binding、AWS resourceを追加しない。
-
-## AWS案
-
-### 現在のNext.js 16 FoundationではAmplifyを採用しない
-
-AWSが現時点で公式に記載しているmanaged Amplify HostingのNext.js対応範囲はversion 15までであり、本projectのNext.js 16方針とversion差がある。
-
-AWSがNext.js 16対応を明示し、Payloadで利用する機能が実Deploy Previewを通過した時点で再評価する。
-
-### AWS-firstのfull runtime
-
-長期的なAWS native構成の候補:
+長期的なAWS native候補:
 
 ```text
 Route 53
   -> CloudFront / ALB
-      -> ECS Fargate（Next.js + Payload container）
+      -> ECS Fargate（Next.js + Payload）
           -> RDS/Aurora PostgreSQL
           -> S3
           -> SES
 ```
 
-これはNetlifyより運用負荷が大きい。AWS運用・学習そのものがproduct goalにならない限り、最初のpublic releaseには不要と判断する。
+現時点ではNetlifyより運用負荷が大きいため、AWS運用自体がproduct requirementになるまで移行しない。
 
-### App Runner
-
-新規defaultとして採用しない。AWSはApp Runnerが2026-03-31以降、新規customerの受付を停止したと案内している。既存の対象accountは例外であり、baseline architectureにはしない。
+Amplify等のmanaged Next.js hostingは、採用時点のNext.js/Payload compatibilityを公式Documentationとreal previewで再検証する。
 
 ## Email boundary
 
 Emailはapplication adapterの背後に置く。
 
-現在のIdentity-level mail role:
+- General / Personal -> `ivmz@ivrm.jp`
+- Person-facing -> `ivuru@ivrm.jp`
+- Developer / OSS -> `mizzz@ivrm.jp`
+- ivRooom / Team -> `contact@ivrm.jp`
+- Security -> `security@ivrm.jp`
 
-- General / Personal → `ivmz@ivrm.jp`
-- Person-facing → `ivuru@ivrm.jp`
-- Developer / OSS → `mizzz@ivrm.jp`
-- ivRooom / Team → `contact@ivrm.jp`
-- Security → `security@ivrm.jp`
-
-Cloudflare Email Service / Email Sending SMTPはoutbound mail候補として評価中。Product codeをCloudflare固有primitiveへ直接密結合せず、provider固有処理はadapter / deployment境界へ閉じ込める。
+Product codeを特定mail/DNS provider primitiveへ直接密結合しない。
 
 ## Portability rules
 
 1. 実用上可能な範囲で標準Next.js / Node APIを使用する。
-2. Databaseは `DATABASE_URL` の背後に置く。
+2. Databaseは`DATABASE_URL`の背後に置く。
 3. Object storageはPayload storage adapterの背後に置く。
 4. Emailはapplication adapterの背後に置く。
 5. Anti-abuse / rate limitingは置き換え可能にする。
 6. Page/content codeへDNS-provider固有logicを入れない。
-7. Deployment固有設定は専用fileとADRへ分離する。
-
-## 2026-08-25/26に確認した参考資料
-
-- AWS Amplify — Next.js support: https://docs.aws.amazon.com/amplify/latest/userguide/ssr-amplify-support.html
-- Netlify — Next.js overview: https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview/
-- Payload — Production deployment: https://payloadcms.com/docs/production/deployment
-- Payload — PostgreSQL: https://payloadcms.com/docs/database/postgres
-- Payload — Storage adapters / AWS S3: https://payloadcms.com/docs/upload/storage-adapters
-- AWS App Runner — CreateService availability notice: https://docs.aws.amazon.com/apprunner/latest/api/API_CreateService.html
+7. Deployment固有設定は専用file / Runbook / ADRへ分離する。
+8. Production / Preview / Localのcredentialとpersistent dataを共有しない。

--- a/docs/netlify-bootstrap.md
+++ b/docs/netlify-bootstrap.md
@@ -1,104 +1,188 @@
-# Netlify bootstrap
+# Netlify bootstrap / Production operations
 
-Status: Repository connected; Deploy Preview gate GREEN — 2026-08-26
+Status: Repository connected / Production live / Deploy Preview gate GREEN — updated 2026-08-28
 
-## Repository security baseline
+## Source of Truth
 
-Netlify deployment must not run from a revision older than:
+- Repository: `mizzz-ivr/ivmz-home`
+- Production branch: `main`
+- Netlify project: `ivmz-home`
+- Netlify Site ID: `a6b04c39-d2c7-4996-8ba1-277ccb3532e3`
+- Canonical Production: `https://ivmz.ivrm.jp`
+- Netlify branch alias: `https://main--ivmz-home.netlify.app`
 
-- main merge commit: `0e61e7bbf887a8a132359f9ac0727ff3486d7b21`
+Production releaseはRepositoryのreview済み`main`をSource of Truthとする。固定SHAを恒久的なminimum deploy revisionとして運用せず、deploy時にGitHub `main` HEADとNetlify Production `commit_ref`の一致を確認する。
+
+## Runtime baseline
+
 - Next.js: `16.3.3`
 - eslint-config-next: `16.3.3`
 - package manager: `pnpm@10.17.0`
 - Node.js: 24 series (`engines.node >=24.15.0`)
+- Netlify Next.js integration: `@netlify/plugin-nextjs@5.15.13`
 - committed `pnpm-lock.yaml`
 - CI install: `pnpm install --frozen-lockfile`
 
-This baseline remediates Critical advisory `GHSA-2xp9-vwfh-vxw4` and includes the reduced-motion layout fix carried by PR #2.
+Next.js 16.3.3 baselineはCritical advisory `GHSA-2xp9-vwfh-vxw4` remediationを含む。
 
-## Netlify project
+## Git integration
 
-- Team: `mizzz-dev`
-- Project: `ivumz-home`
-- Site ID: `a6b04c39-d2c7-4996-8ba1-277ccb3532e3`
-- Initial hostname: `https://ivumz-home.netlify.app`
-- Canonical production target: `https://mizzz.ivrm.jp`
-- Existing project `ivuru-web`: unchanged; do not modify, rename, or reuse
+Repository bindingはNetlify UIで完了済み。
 
-## Git binding
+Productionの期待経路:
 
-Repository binding was completed in the Netlify UI on 2026-08-26.
+```text
+GitHub pull request
+  -> CI / Deploy Preview / review
+  -> merge to main
+  -> Netlify Git integration
+  -> Production
+```
 
-Verified from the first Git-backed deployment:
+2026-08-28のPR #24 mergeでは、GitHub `main` merge commit `cf329210e0712af3dfb816e69e03fa94113914c1` がmerge直後にNetlify Productionへ自動deployされ、Netlify `commit_ref`も同一SHA、state `ready`、secret scan 0 matchesを確認した。
 
-- repository commit: `0e61e7bbf887a8a132359f9ac0727ff3486d7b21`
-- production branch: `main`
-- framework: `next`
-- runtime: `nodejs24.x`
-- Netlify Next.js integration: `@netlify/plugin-nextjs@5.15.13`
-- plugin state: `success`
-- deployment state: `ready`
+この確認によりGitHub `main` -> Netlify Productionのcontinuous deployment自体は動作している。
 
-Netlify automatically published the connected `main` revision in `production` context as part of repository linking. This was not a manually-triggered production release. The deployment used the already-remediated security baseline, so there is no vulnerable Next.js 16.3.2 deployment to unwind.
+Netlify deploy metadataの`deploy_source`値だけをGit integration有無の判定材料にしない。Git由来deployかどうかは、merge/push時刻、branch、commit URL、commit title、committer、exact `commit_ref`の一致を合わせて確認する。
 
-No custom production domain or DNS record has been attached yet.
+## Production deployment enforcement
 
-## Configuration policy
+Continuous Deploymentが動作することと、API / CLI / MCPからProductionを直接publishできないことは別のcontrolである。
 
-No `netlify.toml` or hosting-specific workaround is added for the foundation bootstrap unless a real deployment failure proves it necessary.
+ProductionはNetlify **Enforce Git-based deployments** を有効化して、GitHub `main` push以外のProduction publish経路を拒否する。
 
-The application remains portable:
+### Netlify UI
 
-- PostgreSQL is behind `DATABASE_URL`
-- media stays behind the Payload storage adapter boundary
-- email, bot protection, and rate limiting remain replaceable adapters
-- Cloudflare remains DNS-only for now
-- no Workers, D1, native R2 binding, or DNS-provider page logic
+1. Project `ivmz-home` を開く。
+2. `Project configuration` を開く。
+3. `Build & deploy` -> `Continuous deployment` を開く。
+4. Repositoryが `mizzz-ivr/ivmz-home` へ接続されていることを確認する。
+5. Production branchが `main` であることを確認する。
+6. `Enforce deployment methods` -> `Configure` を開く。
+7. Git-based deployment enforcementを有効化する。
+
+有効化後のacceptance:
+
+- `main` pushはProduction deploy可能
+- Deploy Preview / Branch Deployは引き続き利用可能
+- CLI / API / MCPからProductionへの直接publishは拒否される
+- Deploy PreviewをUIから直接Production publishできない
+- Productionに出す変更はPRを`main`へmergeする
+
+設定変更前に現在のknown-good Production deploy IDをrollback referenceとして記録する。Enforce設定自体は解除可能だが、Production failureのrollbackはNetlifyのknown-good deploy restoreを使用する。
+
+## GitHub main guardrail
+
+NetlifyだけでなくGitHub `main`自体をruleset / branch protectionで保護する。
+
+推奨baseline:
+
+- Require a pull request before merging
+- Require repository CI status checks
+- Block force pushes
+- Block branch deletion
+- Require conversation resolutionを利用可能なら有効化
+- Admin bypassは緊急時に本当に必要な範囲だけにする
+
+Repository設定変更後、通常開発は `Issue -> branch -> implementation -> CI -> Draft PR -> Deploy Preview -> review -> merge` を維持する。
+
+## Environment separation
+
+Netlify environment variablesはcontextを分離する。
+
+### DATABASE_URL
+
+- Production -> Supabase `ivrm-core`
+- Deploy Preview -> Supabase `ivmz-home-preview`
+- Branch Deploy -> `ivmz-home-preview`
+- Local / Dev -> Productionとは別の開発接続先
+
+Production dataをPreviewへcloneしない。
+
+### PAYLOAD_SECRET
+
+2026-08-28に次の分離を実施済み。
+
+- Production -> 現行Production専用secret
+- Deploy Preview -> Productionと異なるsecret
+- Branch Deploy -> Production / Deploy Preview双方と異なるsecret
+- Local / CI -> Production secretを使わない
+
+secret値はRepository / Issue / PR / Notion / CI logへ記載しない。
+
+Production secret rotationは旧Production secretを外部secret managerからrecoverできる状態を作ってから行う。Netlifyからmasked値しか取得できない状態で旧secretを上書きしない。
+
+## Preview database migration gate
+
+Deploy Preview / Branch DeployはProduction DBへmigrationを実行しない。
+
+`netlify.toml`のPreview/Branch buildだけが、target guard通過後にRepository migrationを`ivmz-home-preview`へ適用する。
+
+Safety guard:
+
+- contextが`deploy-preview` / `branch-deploy`以外なら拒否
+- `DATABASE_URL`未設定なら拒否
+- Preview Project refと一致しなければ拒否
+- Production Project refは明示的に拒否
+- migration commandのみsession poolingを使用
+- connection stringをlogへ出さない
+
+Production migrationはNetlify buildへ暗黙に組み込まない。
 
 ## Deploy Preview acceptance gate
 
-The Deploy Preview gate is GREEN.
+PRのfinal headでは次を通す。
 
-Validated against the real PR #3 Netlify preview URL with Playwright from GitHub Actions:
+- GitHub CI
+  - format check
+  - lint
+  - typecheck
+  - unit tests
+  - ephemeral PostgreSQL migration
+  - Payload generated artifact drift
+  - Next production build
+- Netlify Deploy Preview success
+- Payload public API preflight
+- Chromium Playwright
+- mobile WebKit Playwright
+- Payload security boundary tests
+- non-existent probe identityによるlogin rate-limit 429 verification
 
-- Deploy Preview alias: `https://deploy-preview-3--ivumz-home.netlify.app`
-- initial validated Deploy ID: `6a8e37d64834840009c2e2ef`
-- framework: `next`
-- runtime: `nodejs24.x`
-- Netlify Next.js integration: `@netlify/plugin-nextjs@5.15.13`
-- plugin state: `success`
-- Next.js Server Handler deployed successfully
-- Edge Functions: none
-- remote Playwright result: `6 passed`
-- desktop browser: Chromium
-- mobile baseline: iPhone 13 / WebKit
+Remote GETの既知transient transport errorはPR #24のshared helperで最大1回だけretryする。HTTP 4xx/5xx、assertion failure、mutation requestはretryしない。
 
-The remote smoke verifies:
+## Production post-deploy acceptance
 
-- root response and primary SSR/RSC DOM content
-- identity heading and primary navigation
-- canonical metadata (`https://mizzz.ivrm.jp`)
-- canonical character image loads through `next/image`
-- `/robots.txt`
-- `/sitemap.xml`
-- responsive mobile rendering baseline
-- `prefers-reduced-motion: reduce` switches About/Writing layered content to static non-overlapping layout
+Production deploy後は最低限次を確認する。
 
-The Playwright configuration keeps local development portable: `E2E_BASE_URL` enables remote deployment smoke, while normal local runs continue to use `pnpm dev` on localhost. Netlify-specific preview URL construction is isolated to `.github/workflows/netlify-preview-smoke.yml` and is not used by application page logic.
+1. Netlify Production `commit_ref` == GitHub `main` HEAD
+2. state `ready`
+3. plugin state success
+4. secret scan 0 matches
+5. `/` と主要public routeが正常
+6. `/admin` login surfaceが正常
+7. Production CORS/CSRF trustへlocalhostを含めない
+8. security headersがpublic/adminへ付与される
+9. CSPは明示承認までReport-Only
+10. anonymous Users / drafts / versions / mutationsが拒否される
+11. Production `DATABASE_URL`がPreview projectを指していない
 
-`mizzz.ivrm.jp` DNS changes happen only after the Netlify deployment baseline is healthy; DNS changes never precede the working Netlify project.
+実admin identityを使ったrate-limit stress testは行わない。
 
-## Baseline production deploy created by Git binding
+## Rollback
 
-- Deploy ID: `6a8e3742ae362707d06a753a`
-- Context: `production`
-- Branch: `main`
-- Commit: `0e61e7bbf887a8a132359f9ac0727ff3486d7b21`
-- State: `ready`
-- Published: `2026-08-26T00:46:32.716Z`
-- HTTPS URL: `https://ivumz-home.netlify.app`
-- Function: Next.js Server Handler
-- Runtime: Node.js 24
-- Edge Functions: none
+Production変更前にcurrent known-good deploy ID / commitを記録する。
 
-This netlify.app deployment is an infrastructure baseline only. `https://mizzz.ivrm.jp` remains unchanged until the merged Netlify bootstrap revision is confirmed healthy in production.
+Application regression時はNetlifyからknown-good deployをrestoreする。
+
+DB migrationが原因でない変更をrollbackするためにProduction DBへ逆DDL/DMLを流さない。
+
+HSTSをsourceから削除してもclient cacheは即時解除されない。緊急解除が必要な場合はHTTPS responseで `Strict-Transport-Security: max-age=0` を返す専用対応が必要。
+
+## Portability policy
+
+- PostgreSQLは`DATABASE_URL`の背後に置く
+- Payload mediaはstorage adapter境界へ置く
+- email / bot protection / rate limitingはreplaceable adapterとして扱う
+- CloudflareはDNS境界に留める
+- hosting provider固有logicをpage/content codeへ入れない
+- Production Git enforcementはdeployment controlでありapplication architectureへ混在させない

--- a/docs/netlify-bootstrap.md
+++ b/docs/netlify-bootstrap.md
@@ -49,7 +49,7 @@ Netlify deploy metadataの`deploy_source`値だけをGit integration有無の判
 
 Continuous Deploymentが動作することと、API / CLI / MCPからProductionを直接publishできないことは別のcontrolである。
 
-ProductionはNetlify **Enforce Git-based deployments** を有効化して、GitHub `main` push以外のProduction publish経路を拒否する。
+2026-08-28、Netlify **Enforce Git-based deployments** を有効化済み。Production publishはGitHub `main`由来へ限定する。
 
 ### Netlify UI
 
@@ -59,9 +59,9 @@ ProductionはNetlify **Enforce Git-based deployments** を有効化して、GitH
 4. Repositoryが `mizzz-ivr/ivmz-home` へ接続されていることを確認する。
 5. Production branchが `main` であることを確認する。
 6. `Enforce deployment methods` -> `Configure` を開く。
-7. Git-based deployment enforcementを有効化する。
+7. Git-based deployment enforcementが有効であることを確認する。
 
-有効化後のacceptance:
+acceptance:
 
 - `main` pushはProduction deploy可能
 - Deploy Preview / Branch Deployは引き続き利用可能
@@ -73,18 +73,21 @@ ProductionはNetlify **Enforce Git-based deployments** を有効化して、GitH
 
 ## GitHub main guardrail
 
-NetlifyだけでなくGitHub `main`自体をruleset / branch protectionで保護する。
+2026-08-28、Repository ruleset `Protect main` をactive化済み。
 
-推奨baseline:
+現在のbaseline:
 
+- default branch `main` を対象
 - Require a pull request before merging
-- Require repository CI status checks
+- required status check: `quality`
+- required status check: `netlify/ivmz-home/deploy-preview`
+- Require conversation resolution
+- Strict required status checks policy
 - Block force pushes
 - Block branch deletion
-- Require conversation resolutionを利用可能なら有効化
-- Admin bypassは緊急時に本当に必要な範囲だけにする
+- bypass actorなし
 
-Repository設定変更後、通常開発は `Issue -> branch -> implementation -> CI -> Draft PR -> Deploy Preview -> review -> merge` を維持する。
+Repository設定変更後も、通常開発は `Issue -> branch -> implementation -> CI -> Draft PR -> Deploy Preview -> review -> merge` を維持する。
 
 ## Environment separation
 
@@ -106,11 +109,12 @@ Production dataをPreviewへcloneしない。
 - Production -> 現行Production専用secret
 - Deploy Preview -> Productionと異なるsecret
 - Branch Deploy -> Production / Deploy Preview双方と異なるsecret
+- Preview Server -> Production / Deploy Preview / Branch Deployと異なる専用secret
 - Local / CI -> Production secretを使わない
 
 secret値はRepository / Issue / PR / Notion / CI logへ記載しない。
 
-Production secret rotationは旧Production secretを外部secret managerからrecoverできる状態を作ってから行う。Netlifyからmasked値しか取得できない状態で旧secretを上書きしない。
+現行Production secretはNetlify上でwrite-only/maskedとなっており、旧実値を後から取得できない。このため、現行Production secretを本Issue完了条件として無理にrotationしない。将来rotationするときは、新secretを先に承認済みsecret managerで生成・保存・recoverability確認してからNetlifyへ反映し、その後のrotation世代からrollback可能な運用へ移行する。
 
 ## Preview database migration gate
 
@@ -173,6 +177,8 @@ Production deploy後は最低限次を確認する。
 Production変更前にcurrent known-good deploy ID / commitを記録する。
 
 Application regression時はNetlifyからknown-good deployをrestoreする。
+
+古いdeployをrestoreした場合、Production `commit_ref`は一時的にGitHub `main` HEADと不一致になり得る。このrestoreは緊急時の一時例外として扱い、直ちに`main`側へrevertまたはforward-fix PRを作成してreview/CIを通し、GitとProductionを再収束させる。再収束するまで無関係な変更をProductionへ流さない。
 
 DB migrationが原因でない変更をrollbackするためにProduction DBへ逆DDL/DMLを流さない。
 

--- a/docs/payload-security-operations.md
+++ b/docs/payload-security-operations.md
@@ -2,8 +2,21 @@
 
 ## Scope
 
-このRunbookはProduction公開中のPayload Admin / Auth hardeningに関する運用手順を整理する。
+このRunbookはProduction公開中のPayload Admin / Auth hardeningと、Security rollout後の継続運用手順を整理する。
+
 Secret値そのものはRepository、Issue、PR、CI log、Notionへ記載しない。
+
+Repositoryは `mizzz-ivr/ivmz-home`、Production canonicalは `https://ivmz.ivrm.jp` を正とする。
+
+## Current security posture — 2026-08-28
+
+- Payload Admin / Auth hardening: Production反映済み
+- Netlify Deploy Preview / Branch Deploy database: Productionから分離済み
+- Deploy Preview / Branch Deploy `PAYLOAD_SECRET`: Productionから分離済み、かつ相互にも別secret
+- Production `PAYLOAD_SECRET`: 未rotation
+- CSP: `Content-Security-Policy-Report-Only` のまま運用
+- Production / Preview Supabase `ivmz_home`: client rolesから直接到達不能をread-onlyで再確認済み
+- Production DBへのfixture / destructive DDL/DML: 実施しない
 
 ## Origin policy
 
@@ -18,7 +31,7 @@ Secret値そのものはRepository、Issue、PR、CI log、Notionへ記載しな
 
 Payload標準のaccount lockoutを維持したまま、Netlify code-based rate limitingを前段へ追加する。
 
-今回のP1 protectionはcredential stuffing / password sprayingの主入口であるPayload login endpointへ絞る。
+P1 protectionはcredential stuffing / password sprayingの主入口であるPayload login endpointへ絞る。
 
 - 対象: `/api/users/login`
 - 実装: Netlify Edge Functionのcode-based rate limit
@@ -26,11 +39,9 @@ Payload標準のaccount lockoutを維持したまま、Netlify code-based rate l
 - limit: 10 requests / 60 seconds / domain + client IP
 - 超過時: HTTP 429
 - memory-only limiterは使用しない
-- Deploy Preview smokeで存在しないprobe accountを使い、実環境で429を確認する
+- Deploy Preview smokeでは存在しないprobe accountを使い、実環境で429を確認する
 
-Netlifyのcode-based rate limitingはpath targetingが基本なので、Edge Function側でHTTP method条件へ依存せずlogin path単位で設定する。Payload login routeの正規利用はPOSTであり、IP + domain aggregationのため別clientのlogin枠を共有しない。
-
-`forgot-password` / `reset-password` / `unlock` / `refresh-token` / `verify`は同じrate-limit ruleへ安易にまとめず、実際のabuse modelとNetlify側のcode-based rule budgetを確認した上で必要なendpointだけを追加する。
+`forgot-password` / `reset-password` / `unlock` / `refresh-token` / `verify`は同じrate-limit ruleへ安易にまとめない。実際のabuse modelとNetlify側のrule budgetを確認し、必要なendpointだけを追加する。
 
 rate limit probeでは実在Adminのemail/passwordを使用しない。
 
@@ -45,45 +56,157 @@ Baselineとして以下を全routeへ付与する。
 - `X-Frame-Options`
 - `Content-Security-Policy-Report-Only`
 
-CSPはPayload Adminへの影響を避けるためReport-Onlyから開始する。`unsafe-inline` / `unsafe-eval` を安易に許可せず、Previewでconsole/reportを確認してからenforce policyを別変更として扱う。
+Next.jsの`poweredByHeader`は無効化する。
+
+### CSP rollout policy
+
+CSPはPayload AdminやNext.js runtimeを壊さないことを優先し、Report-Onlyから開始する。
+
+現行baselineは `default-src 'self'` / `base-uri 'self'` / `object-src 'none'` / `frame-ancestors 'self'` をReport-Onlyで提示している。Next.js / Payload Adminが生成するinline script/style等は実際のviolation観測を行ってからsourceを精査する。
+
+- `unsafe-inline` / `unsafe-eval` を観測なしで追加しない
+- Report-Onlyのままreal Production/Preview violationを確認する
+- enforce化は独立PRとする
+- enforce PRにはpublic routes + `/admin` + Payload API regression acceptanceを必須とする
 
 ## PAYLOAD_SECRET isolation / rotation
 
-### Current risk
+### Current state
 
-Production / Deploy Preview / Branch Deployで同一の`PAYLOAD_SECRET`を共有すると、Previewの侵害がProduction auth secretの侵害へ波及する可能性がある。
+2026-08-28にNetlify contextを再確認し、以下へ分離した。
 
-### Desired context split
+- Production: 現行Production専用secretを維持
+- Deploy Preview: Productionと異なるPreview専用secret
+- Branch Deploy: Production / Deploy Previewの両方と異なるBranch専用secret
+- Local / CI: Production secretを利用しない
 
-- Production: Production専用secret
-- Deploy Preview: Preview専用secret
-- Branch Deploy: Branch Deploy専用secret
-- Local / CI: Productionとは無関係なdevelopment / CI secret
+値そのものは記録しない。
 
-### Impact
+### Why split contexts
 
-`PAYLOAD_SECRET`はPayloadの暗号化workflowとauth token/cookieの署名に使われるため、Production rotationは既存session/tokenを無効化し得る。secret変更自体はDB schema migrationを必要としないが、既存の暗号化済みデータを利用している機能がある場合はrotation前に影響確認が必要。
+Production / Deploy Preview / Branch Deployで同じ`PAYLOAD_SECRET`を共有すると、Preview側の侵害がProduction auth secretの侵害へ波及する可能性がある。Preview/Branchを独立secretにすることでblast radiusを分離する。
 
-### Safe sequence
+### Impact of rotation
 
-1. NetlifyのDeploy Preview / Branch DeployをProductionと異なるsecretへ分離する。
-2. Previewをdeployし、Admin login / logout、Payload API、rate limit、security E2Eを確認する。
-3. Production rotation前に現在値を安全なsecret store側でrollback用として保持する。値をIssue / PR / logへ出さない。
-4. maintenance windowを確保し、Production contextだけ新しいsecretへ更新する。
-5. Production deploy完了後、Admin login / logout、session再生成、public API、CMS read/writeを確認する。
-6. 問題があれば旧Production secretへ戻してredeployする。
+`PAYLOAD_SECRET`はPayloadの暗号化workflowとauth token/cookieの署名に使われるため、Production rotationは既存session/tokenを無効化し得る。
 
-### Rollback caveat
+secret変更自体はDB schema migrationを必要としないが、暗号化済みデータを利用する機能が追加された場合はrotation前に影響確認をやり直す。
 
-旧secretへrollbackすると旧secretで署名されたsession/tokenが再び有効になり得る一方、新secretで発行されたsession/tokenは無効になる。rotation/rollback時は全Adminへ再loginを前提として通知する。
+### Preview validation sequence
+
+1. Deploy Preview / Branch DeployをProductionと異なるsecretへ分離する。
+2. fresh Deploy Previewを作成する。
+3. build / Payload migration guard / public API preflightを通す。
+4. `/admin` login surfaceを確認する。
+5. anonymous Users / draft / versions / mutation denialを確認する。
+6. login rate-limit 429をnon-existent probe identityで確認する。
+7. Chromium / mobile WebKit regressionを通す。
+
+Preview側にProduction dataやProduction credentialをコピーしない。
+
+### Production rotation gate
+
+Production rotationは、次をすべて満たすまで実行しない。
+
+1. **現在のProduction secretの実値を、Netlifyとは別の承認済みsecret managerへrollback用として保存できていること。**
+2. 保存した値を実際に復旧時に取得できることを確認すること。
+3. fresh Previewで分離secretのacceptanceが完了していること。
+4. Production rollback deploy referenceを記録していること。
+5. Admin再loginが必要になる可能性を許容できること。
+6. Production change window中にpublic/API/CMS acceptanceを実施できること。
+
+Netlify API/MCPからmasked secretしか取得できず旧値を復元できない場合、その状態でProduction secretを上書きしてはいけない。
+
+### Production rotation sequence
+
+1. rollback用旧secretのrecoverabilityを確認する。
+2. Production contextだけ新しいsecretへ更新する。
+3. Git `main`由来のProduction deployを実行する。
+4. exact `main` commit / deploy `ready` / secret scan 0件を確認する。
+5. public routes / Payload public APIを確認する。
+6. 正規Adminでloginし、新sessionが発行されることを確認する。
+7. CMS read/writeとlogoutを確認する。
+8. 問題がなければ旧secretをrotation rollback専用保管へ移す。
+
+### Rollback
+
+問題がある場合は、保存済みの旧Production secretへ戻してGit由来のProduction redeployを行う。
+
+旧secretへrollbackすると旧secretで署名されたsession/tokenが再び有効になり得る一方、新secretで発行されたsession/tokenは無効になる。rotation/rollback時は全Adminへ再loginを前提とする。
 
 ## Preview database isolation
 
-Deploy Preview / Branch DeployがProductionと同じ`DATABASE_URL`を共有する状態は別のattack surfaceであり、Issue #18で分離する。
+Issue #18 / PR #21でPreview database分離を完了済み。
 
-- #17ではDB topologyを変更しない
-- Production/shared DBへtest fixtureを投入しない
-- Preview DB分離時はcost、migration、seed、lifecycle、rollback、E2Eを先に設計する
+| Context | Database | Schema | Data policy |
+| --- | --- | --- | --- |
+| Production | Supabase `ivrm-core` | `ivmz_home` | Production data |
+| Deploy Preview | Supabase `ivmz-home-preview` | `ivmz_home` | Production dataを持たない |
+| Branch Deploy | `ivmz-home-preview` | `ivmz_home` | Production dataを持たない |
+| GitHub CI | ephemeral PostgreSQL | `ivmz_home` | test only |
+| Local | local/dev PostgreSQL | `ivmz_home` | local only |
+
+Preview/Branch migrationはRepository `src/migrations/` をSource of Truthとし、Netlify context guardを通過した場合だけ実行する。Production buildからPreview migration commandを実行しない。
+
+## Supabase / Payload database boundary
+
+2026-08-28のread-only再確認:
+
+### Production
+
+- schema owner: dedicated application role `ivmz_home_app`
+- `anon`: schema USAGEなし / Payload tables SELECT・mutationなし
+- `authenticated`: schema USAGEなし / Payload tables SELECT・mutationなし
+- `service_role`: schema USAGEなし / Payload tables SELECT・mutationなし
+- `ivmz_home_app`: login可能 / non-superuser / `BYPASSRLS=false` / Payload tablesへの必要なread/writeあり
+- Payload-managed 25 tables: RLS disabled
+
+Supabaseの`service_role`自体はplatform roleとして`BYPASSRLS=true`だが、`ivmz_home`へのschema/table grantsを持たないため、このcustom schemaへ直接到達できない境界を維持する。
+
+### Preview
+
+- schema owner: `postgres`
+- `anon` / `authenticated` / `service_role`: schema USAGEなし / Payload tables read-writeなし
+- Payload-managed 25 tables: RLS disabled
+- Preview runtimeはProduction dataを持たない
+
+### RLS decision
+
+RLS disabled advisoryだけを根拠にPayload-managed schemaへ一括RLSを導入しない。
+
+現在のauthorization boundaryは次の2層:
+
+1. PostgreSQL grantsでSupabase client rolesから`ivmz_home`を到達不能にする。
+2. Payload server-side connection + Payload Access Controlでapplication authorizationを行う。
+
+schema grant / Data API exposure / runtime roleを変更する場合は、RLS posture reviewを再実施する。
+
+## Production deployment guardrail
+
+Production publishの原則経路は次の通り。
+
+```text
+GitHub reviewed PR
+  -> merge to main
+  -> Netlify Git integration
+  -> Production
+```
+
+Netlifyでは **Enforce Git-based deployments** を有効化し、CLI / API / MCP / Deploy Previewの直接Production publishを拒否する。
+
+Netlify UI:
+
+1. Project `ivmz-home`
+2. Project configuration
+3. Build & deploy
+4. Continuous deployment
+5. Enforce deployment methods
+6. Configure
+7. Git-based Production deployment enforcementを有効化
+
+有効化後もDeploy Preview / Branch Deployの非Production deployは利用できる。
+
+GitHub側では`main`をruleset / branch protectionで保護し、PR経由・CI成功・force-push/deletion禁止を基本とする。
 
 ## Acceptance checklist
 
@@ -93,5 +216,10 @@ Deploy Preview / Branch DeployがProductionと同じ`DATABASE_URL`を共有す�
 - Users / drafts / versions / mutationsがanonymousへ漏れない
 - error responseへsecret / connection string / stack traceを漏らさない
 - Public page / Payload Adminにsecurity headersが付く
+- CSPは明示的なenforce承認までReport-Only
 - Deploy Previewでlogin rate limitが429を返す
+- Production / Preview / Branchの`PAYLOAD_SECRET`を共有しない
+- Production DBとPreview DBを共有しない
+- client rolesへ`ivmz_home` grantsを与えない
+- Production publishをreviewed Git `main`へ限定する
 - 正規Admin login / logoutと既存CMS運用を壊さない

--- a/docs/payload-security-operations.md
+++ b/docs/payload-security-operations.md
@@ -12,8 +12,10 @@ Repositoryは `mizzz-ivr/ivmz-home`、Production canonicalは `https://ivmz.ivrm
 
 - Payload Admin / Auth hardening: Production反映済み
 - Netlify Deploy Preview / Branch Deploy database: Productionから分離済み
-- Deploy Preview / Branch Deploy `PAYLOAD_SECRET`: Productionから分離済み、かつ相互にも別secret
-- Production `PAYLOAD_SECRET`: 未rotation
+- Deploy Preview / Branch Deploy / Preview Server / Local `PAYLOAD_SECRET`: Productionから分離済み
+- Production `PAYLOAD_SECRET`: 現行legacy secretを維持、未rotation
+- Netlify **Enforce Git-based deployments**: owner設定済み
+- GitHub Ruleset `Protect main`: active
 - CSP: `Content-Security-Policy-Report-Only` のまま運用
 - Production / Preview Supabase `ivmz_home`: client rolesから直接到達不能をread-onlyで再確認済み
 - Production DBへのfixture / destructive DDL/DML: 実施しない
@@ -73,18 +75,19 @@ CSPはPayload AdminやNext.js runtimeを壊さないことを優先し、Report-
 
 ### Current state
 
-2026-08-28にNetlify contextを再確認し、以下へ分離した。
+2026-08-28にNetlify contextを分離した。
 
-- Production: 現行Production専用secretを維持
+- Production: 現行Production専用legacy secretを維持
 - Deploy Preview: Productionと異なるPreview専用secret
 - Branch Deploy: Production / Deploy Previewの両方と異なるBranch専用secret
+- Preview Server: Production / Deploy Preview / Branch Deployと異なる専用secret
 - Local / CI: Production secretを利用しない
 
 値そのものは記録しない。
 
 ### Why split contexts
 
-Production / Deploy Preview / Branch Deployで同じ`PAYLOAD_SECRET`を共有すると、Preview側の侵害がProduction auth secretの侵害へ波及する可能性がある。Preview/Branchを独立secretにすることでblast radiusを分離する。
+Productionと非Production contextで同じ`PAYLOAD_SECRET`を共有すると、Preview / Branch / Preview Server / Local側の侵害がProduction auth secretの侵害へ波及する可能性がある。contextごとに独立secretを使いblast radiusを分離する。
 
 ### Impact of rotation
 
@@ -94,7 +97,7 @@ secret変更自体はDB schema migrationを必要としないが、暗号化済�
 
 ### Preview validation sequence
 
-1. Deploy Preview / Branch DeployをProductionと異なるsecretへ分離する。
+1. Deploy Preview / Branch Deploy / Preview ServerをProductionと異なるsecretへ分離する。
 2. fresh Deploy Previewを作成する。
 3. build / Payload migration guard / public API preflightを通す。
 4. `/admin` login surfaceを確認する。
@@ -104,35 +107,46 @@ secret変更自体はDB schema migrationを必要としないが、暗号化済�
 
 Preview側にProduction dataやProduction credentialをコピーしない。
 
-### Production rotation gate
+### Current Production rotation decision
 
-Production rotationは、次をすべて満たすまで実行しない。
+現行Production secretはNetlify上でwrite-only / maskedとして保存されており、そのraw legacy valueを後から取得できない。
 
-1. **現在のProduction secretの実値を、Netlifyとは別の承認済みsecret managerへrollback用として保存できていること。**
-2. 保存した値を実際に復旧時に取得できることを確認すること。
-3. fresh Previewで分離secretのacceptanceが完了していること。
-4. Production rollback deploy referenceを記録していること。
-5. Admin再loginが必要になる可能性を許容できること。
-6. Production change window中にpublic/API/CMS acceptanceを実施できること。
+そのため、Security rollout完了のためだけにProduction secretを上書きしない。現時点ではrotationを**deferred**とする。
 
-Netlify API/MCPからmasked secretしか取得できず旧値を復元できない場合、その状態でProduction secretを上書きしてはいけない。
+現行legacy secretから最初のmanaged secretへ切り替える場合、legacy raw valueへ戻すsecret-level rollbackはできない。この最初の切替は通常のrotationではなく、**明示承認されたone-way cutover**として扱う。
 
-### Production rotation sequence
+### First managed-secret cutover gate
 
-1. rollback用旧secretのrecoverabilityを確認する。
-2. Production contextだけ新しいsecretへ更新する。
-3. Git `main`由来のProduction deployを実行する。
-4. exact `main` commit / deploy `ready` / secret scan 0件を確認する。
+最初のProduction cutoverは次をすべて満たした場合だけ実施する。
+
+1. 新しいProduction secretをapproved secret managerで生成する。
+2. Netlifyへ設定する前に、新secretをsecret managerへ保存する。
+3. 保存済み新secretを実際にrecoverできることを確認する。
+4. legacy secretへ戻せないone-way cutoverであることを明示的に受け入れる。
+5. current known-good Production deploy ID / commitを記録する。
+6. fresh Preview acceptanceがGREENであることを確認する。
+7. Admin再loginが必要になる可能性を許容できるmaintenance windowで実施する。
+8. public/API/CMS acceptanceを直ちに実施できることを確認する。
+
+### First managed-secret cutover sequence
+
+1. approved secret manager上の新secret recoverabilityを再確認する。
+2. Netlify Production contextだけを新secretへ更新する。
+3. reviewed Git `main`由来のProduction deployを実行する。
+4. exact `main` commit / deploy `ready` / plugin success / secret scan 0件を確認する。
 5. public routes / Payload public APIを確認する。
 6. 正規Adminでloginし、新sessionが発行されることを確認する。
-7. CMS read/writeとlogoutを確認する。
-8. 問題がなければ旧secretをrotation rollback専用保管へ移す。
+7. CMS read/write / logout / 再loginを確認する。
+8. 問題がある場合も未知のlegacy secretへ戻そうとせず、新managed secretを維持したままapplication側をrevert / forward-fixする。
+9. acceptance完了後、新managed secretを以後のrecoverable baselineとする。
 
-### Rollback
+### Subsequent rotation / rollback
 
-問題がある場合は、保存済みの旧Production secretへ戻してGit由来のProduction redeployを行う。
+最初のmanaged-secret cutover完了後は、各rotation前に現在のmanaged secretがsecret managerからrecoverableであることを確認する。
 
-旧secretへrollbackすると旧secretで署名されたsession/tokenが再び有効になり得る一方、新secretで発行されたsession/tokenは無効になる。rotation/rollback時は全Adminへ再loginを前提とする。
+次世代secretを事前保存してからProductionへ反映し、問題がある場合は保存済みの直前managed secretへ戻してreviewed Git `main`由来でredeployする。
+
+旧managed secretへrollbackすると旧secretで署名されたsession/tokenが再び有効になり得る一方、新secretで発行されたsession/tokenは無効になる。rotation/rollback時は全Adminへ再loginを前提とする。
 
 ## Preview database isolation
 
@@ -192,21 +206,20 @@ GitHub reviewed PR
   -> Production
 ```
 
-Netlifyでは **Enforce Git-based deployments** を有効化し、CLI / API / MCP / Deploy Previewの直接Production publishを拒否する。
+2026-08-28、Netlify **Enforce Git-based deployments** はowner設定済み。Production publishはreviewed Git `main`由来へ限定する。
 
-Netlify UI:
+GitHub側もRepository Ruleset `Protect main` をactive化済み。
 
-1. Project `ivmz-home`
-2. Project configuration
-3. Build & deploy
-4. Continuous deployment
-5. Enforce deployment methods
-6. Configure
-7. Git-based Production deployment enforcementを有効化
+- Require Pull Request
+- required status check: `quality`
+- required status check: `netlify/ivmz-home/deploy-preview`
+- Require conversation resolution
+- strict required status checks policy
+- force-push禁止
+- deletion禁止
+- bypass actorなし
 
 有効化後もDeploy Preview / Branch Deployの非Production deployは利用できる。
-
-GitHub側では`main`をruleset / branch protectionで保護し、PR経由・CI成功・force-push/deletion禁止を基本とする。
 
 ## Acceptance checklist
 
@@ -218,7 +231,7 @@ GitHub側では`main`をruleset / branch protectionで保護し、PR経由・CI�
 - Public page / Payload Adminにsecurity headersが付く
 - CSPは明示的なenforce承認までReport-Only
 - Deploy Previewでlogin rate limitが429を返す
-- Production / Preview / Branchの`PAYLOAD_SECRET`を共有しない
+- Production / Deploy Preview / Branch Deploy / Preview Server / Localで`PAYLOAD_SECRET`を共有しない
 - Production DBとPreview DBを共有しない
 - client rolesへ`ivmz_home` grantsを与えない
 - Production publishをreviewed Git `main`へ限定する

--- a/docs/payload-security-operations.md
+++ b/docs/payload-security-operations.md
@@ -144,9 +144,13 @@ Preview側にProduction dataやProduction credentialをコピーしない。
 
 最初のmanaged-secret cutover完了後は、各rotation前に現在のmanaged secretがsecret managerからrecoverableであることを確認する。
 
-次世代secretを事前保存してからProductionへ反映し、問題がある場合は保存済みの直前managed secretへ戻してreviewed Git `main`由来でredeployする。
+次世代secretを事前生成・保存しrecoverabilityを確認してからProductionへ反映する。
 
-旧managed secretへrollbackすると旧secretで署名されたsession/tokenが再び有効になり得る一方、新secretで発行されたsession/tokenは無効になる。rotation/rollback時は全Adminへ再loginを前提とする。
+- 定期rotationや設定変更など、**直前secretがcompromiseしていないと確認できる通常変更**で問題が発生した場合だけ、保存済みの直前managed secretへrollbackしてreviewed Git `main`由来でredeployできる。
+- 漏えい・盗難・不正利用など**直前secretのcompromiseが疑われるincident response**では、その直前secretへrollbackしない。切替先secretで問題が発生した場合は、さらに別の新しいsecretを生成・保存・recoverability確認したうえでroll-forwardし、application側もrevert / forward-fixして復旧する。
+- compromiseした可能性のあるsecretで署名されたsession/tokenは再び有効化しない。必要に応じて全Admin session無効化・credential reviewなどincident responseを行う。
+
+安全な通常rollbackで旧managed secretへ戻した場合でも、旧secretで署名されたsession/tokenが再び有効になり得る一方、新secretで発行されたsession/tokenは無効になる。rotation / rollback / roll-forward時は全Adminへ再loginを前提とする。
 
 ## Preview database isolation
 


### PR DESCRIPTION
## Summary

Tracks #27.

Post-security rollout後の実運用状態へRunbookを揃えるdocs-only changeです。

- document exact Git `main` -> Netlify Production workflow
- record Netlify **Enforce Git-based deployments** as enabled
- record active GitHub `main` Ruleset baseline
- record Deploy Preview / Branch Deploy / Preview Server / Local `PAYLOAD_SECRET` separation from Production
- define the safe Production secret lifecycle without exposing secret values
- define the first legacy -> managed secret change as an explicitly approved one-way cutover
- distinguish safe routine rollback from compromise-driven roll-forward
- update dedicated `ivmz-home-preview` database topology
- align Netlify serverless transaction pooling / Preview migration session-mode documentation with current code
- record Supabase/Payload grants boundary and RLS decision
- keep CSP Report-Only and define enforcement readiness gate
- define deploy rollback reconvergence: restored older deploy is temporary; `main` must immediately revert/forward-fix until Git and Production converge again

## Changed Runbooks

- `docs/payload-security-operations.md`
- `docs/netlify-bootstrap.md`
- `docs/hosting.md`
- `docs/database-runtime.md`

## Current verified baseline — 2026-08-28

- current `main`: `0f19720fe8bd7d5d6b5194c01e17fe5f52ae36b9` (PR #26 merge)
- Netlify Production: exact same commit / `ready` / `manual_deploy=false` / plugin success / secret scan 0 matches
- Netlify **Enforce Git-based deployments**: owner enabled
- GitHub Ruleset `Protect main`: active
  - PR required
  - `quality` required
  - `netlify/ivmz-home/deploy-preview` required
  - conversation resolution required
  - strict up-to-date status checks
  - force-push / deletion blocked
  - no bypass actors
- Deploy Preview / Branch Deploy / Preview Server / Local `PAYLOAD_SECRET`: Productionから分離済み
- Production `PAYLOAD_SECRET`: intentionally not rotated; current legacy raw value is not recoverable from Netlify after the fact
- first managed-secret migration: explicit one-way cutover after the new secret is generated/stored/recoverability-checked in an approved secret manager
- subsequent routine rotation: previous managed secret may be used for rollback only when it is known not to be compromised
- suspected compromise: never restore the suspected secret; generate/store/verify another new secret and roll forward
- Supabase Production / Preview grant review: read-only only; no DB change
- CSP remains Report-Only; enforcement work is tracked by #29

## Current PR head

`15c7e82b4e166ab3bd895606b14b30b82acc389c`

The branch is synchronized with current `main` and the PR diff remains docs-only (4 files, behind=0).

## Security constraints

- no secret values in this PR
- no Production DB DDL/DML
- no Production data copy to Preview
- no Production PAYLOAD_SECRET rotation
- no CSP enforcement
- no RLS bulk enablement

## Acceptance — exact current head

- [x] CI #333 success
- [x] Netlify Deploy Preview exact `15c7e82b4e166ab3bd895606b14b30b82acc389c` / `ready` / plugin success
- [x] Deploy Preview secret scan: 0 matches / 213 files scanned
- [x] Netlify Preview Smoke #302 success
  - exact-head Deploy Preview wait
  - Payload public API preflight
  - Chromium / mobile WebKit Playwright smoke
  - Payload auth rate-limit 429 verification using a non-existent probe identity
- [x] current branch contains latest `main` / behind=0
- [x] changed files remain docs-only
- [x] deploy rollback reconciliation review feedback addressed
- [x] unrecoverable legacy secret first-cutover feedback addressed
- [x] compromise rotation rollback feedback addressed
- [x] unresolved review threads = 0
- [x] requested changes = none
- [x] mergeable = true

## Merge policy

Do not merge until the repository owner explicitly requests merge.