### PR TITLE
security: add CSP Report-Only observation harness

### DIFF
--- a/docs/csp-observation.md
+++ b/docs/csp-observation.md
@@ -85,6 +85,27 @@ NetlifyはCSP reporting functionやthird-party collectorも利用できるが、
 
 violationが存在すること自体ではfailしない。Issue #29のPhase Bではviolationが観測対象だからである。
 
+Remote navigationだけは既知の一時的transport/navigation failureに限り最大2回まで試行する。HTTP status assertion、CSP header assertion、violation分類自体はretryしない。retry diagnosticには固定route labelとattempt以外のrequest/response情報を出さない。
+
+## Deploy Preview inventory — 2026-08-28
+
+Exact-head Deploy Preview Smoke run `#309` / commit `cc26be416ce6ade0a1810d974c25fda9422a5fd4` はChromium / mobile WebKitともGREEN。
+
+両browserで共通して観測したsanitized inventory:
+
+| Surface | Effective directive / blocked category | Classification |
+| --- | --- | --- |
+| public routes | `script-src-elem` / `inline` | Next.js / React framework requirement candidate |
+| public routes | `style-src-attr` / `inline` | framework/application rendering requirement candidate |
+| `/admin` login surface | `script-src-elem` / `inline` | shared Next.js / React requirement candidate |
+| `/admin` login surface | `style-src-attr` / `inline` | shared rendering requirement candidate |
+| `/admin` login surface | `style-src-elem` / `inline` | Payload Admin-specific requirement candidate |
+| Deploy Preview | `frame-src` / `https://app.netlify.com` | Netlify Deploy Preview environment; do not promote to Production allowlist |
+
+観測上、`unsafe-eval`を要求するviolationは確認していない。外部`script` / `img` / `font` / `connect` / `worker` originをProduction policyへ追加すべき証拠も、このPreview inventoryからは得られていない。
+
+この結果から、Payload Adminだけ追加のinline style requirementを持つため、public routesと`/admin`のpolicy分離は有力candidateとして残す。ただしauthenticated Admin operationまで観測する前に確定しない。
+
 ## Production public / login-surface observation
 
 Productionへの観測も同じspecを使用する。read-only public routesと`/admin` login surfaceにはcredential不要。
@@ -181,11 +202,23 @@ Next.js公式はrequestごとのnonceをCSP headerへ入れるstrict CSPをサ�
 
 ### Candidate B — SRI / hash-based CSP
 
-Next.jsにはSRIによるhash-based CSP supportがあるが、現時点ではexperimentalでApp Router + webpack限定。
+Next.jsのSRIについては、**16.3.3時点で公式情報に整合しない記述があるため、webpack opt-outの要否をRunbook上で断定しない**。
 
-`ivmz-home`はNext.js 16系で、Next.js 16は`next build`のdefault bundlerがTurbopackである。SRIを採用するにはwebpackへopt-outする必要があり、build pipeline / deploy behaviorの変更を伴う。
+確認済みの公式情報:
 
-したがってSRIも観測前には採用しない。
+- CSP guideは`experimental.sri`をexperimental / App Router / webpack-onlyと記載している。
+- Turbopack API referenceにも`experimental.sri.algorithm`をTurbopack未対応featureとして記載している。
+- 一方、Next.js 16.2 release notes / Turbopack 16.2 release notesはJavaScript filesのSRI supportをTurbopack improvementとして明記している。
+
+したがって、enforcement PRを作る前に**exact Next.js `16.3.3` + current Netlify build pipeline**で小さなPreview spikeを行い、次を実測する:
+
+1. Turbopack buildで`experimental.sri`が実際に有効か。
+2. emitted external JavaScriptへ`integrity`が付与されるか。
+3. inline React Server Components / flight scriptsがstrict `script-src`で残るか。
+4. CDN/Netlify配信後もintegrity hashが一致するか。
+5. `style-src-attr` / `style-src-elem` requirementをSRIでは解決できないことを前提に別strategyが必要か。
+
+SRIはexternal JavaScript integrityとinline script/style CSP許可を同一問題として扱わない。Preview inventoryではinline script/styleが実際に主要violationなので、SRI単独をenforcement solutionとはみなさない。
 
 ### Candidate C — public / Admin policy separation
 
@@ -215,19 +248,20 @@ Next.jsにはSRIによるhash-based CSP supportがあるが、現時点ではexp
 
 次を満たしてからenforcement candidate実装へ進む。
 
-- Chromium Deploy Preview inventory
-- mobile WebKit Deploy Preview inventory
-- Production public/login-surface inventory
-- authenticated Admin inventory
-- framework / Payload / application / third-party分類
-- required origin / inline requirementに証拠がある
-- unnecessary sourceをallowlistへ含めない
-- rendering / cache impactを候補ごとに記録する
+- [x] Chromium Deploy Preview inventory
+- [x] mobile WebKit Deploy Preview inventory
+- [ ] Production public/login-surface inventory
+- [ ] authenticated Admin inventory
+- [x] Previewのframework / Payload / application / third-party初期分類
+- [ ] authenticated Adminを含むrequired origin / inline requirementに証拠がある
+- [x] Preview由来の不要sourceをProduction allowlistへ含めない方針
+- [x] rendering / cache impactをcandidateごとに記録
 
 ## Official references
 
 - Next.js CSP: https://nextjs.org/docs/app/guides/content-security-policy
 - Next.js 16 upgrade / Turbopack default: https://nextjs.org/docs/app/guides/upgrading/version-16
+- Next.js 16.2 release notes: https://nextjs.org/blog/next-16-2
 - Payload Admin overview: https://payloadcms.com/docs/admin/overview
 - Payload production deployment: https://payloadcms.com/docs/production/deployment
 - Netlify CSP: https://docs.netlify.com/manage/security/content-security-policy/

--- a/docs/csp-observation.md
+++ b/docs/csp-observation.md
@@ -257,6 +257,11 @@ SRIはexternal JavaScript integrityとinline script/style CSP許可を同一問�
 - [x] Preview由来の不要sourceをProduction allowlistへ含めない方針
 - [x] rendering / cache impactをcandidateごとに記録
 
+## Validation history
+
+- Iteration head `16378105fa3861bf821bdc4bfc187d7632b210f1`: CI `#343` success。format / lint / typecheck / unit / migration / generated artifacts / buildを通過。
+- Final exact-head Deploy PreviewはこのRunbook更新commitを対象に、PR titleから`[skip netlify]`を外した状態で実施する。
+
 ## Official references
 
 - Next.js CSP: https://nextjs.org/docs/app/guides/content-security-policy

--- a/docs/csp-observation.md
+++ b/docs/csp-observation.md
@@ -1,0 +1,233 @@
+# CSP Report-Only Observation Runbook
+
+## Scope
+
+Issue #29のための、`Content-Security-Policy-Report-Only` violation観測とenforcement candidate設計手順。
+
+Productionへreport collector、debug endpoint、unsafe policyを追加せず、Playwrightのbrowser-side `securitypolicyviolation` eventだけを使う。
+
+Production enforceはこのRunbookの対象外。enforceはreal observation完了後の独立PRとする。
+
+## Current baseline — 2026-08-28
+
+- Next.js: `16.3.3`
+- Payload: `3.88.0`
+- Payload Admin: Next.js App Router上の`/admin`
+- current header: `Content-Security-Policy-Report-Only`
+- current policy:
+
+```text
+default-src 'self';
+base-uri 'self';
+object-src 'none';
+frame-ancestors 'self'
+```
+
+- explicit `script-src` / `style-src` nonce/hash strategy: none
+- Production enforce: disabled
+
+## Why observation stays outside Production
+
+NetlifyはCSP reporting functionやthird-party collectorも利用できるが、Issue #29ではまずapplicationへcollectorを追加しない。
+
+理由:
+
+- Production request metadataを新しい保存先へ送らない
+- accidental query string / document URL / source sample collectionを避ける
+- additional function / retention / access-control boundaryを増やさない
+- zero-costで観測できる
+- Report-Only policy自体を変更せず実行できる
+
+観測は`tests/e2e/csp-observation.spec.ts`で行う。
+
+## Data minimization
+
+観測結果へ出力してよい情報:
+
+- fixed route label
+- Playwright project name
+- `effectiveDirective`
+- `violatedDirective`
+- `disposition`
+- blocked resourceのsanitized category
+  - same-origin -> `'self'`
+  - external URL -> origin only
+  - `data:` / `blob:` -> scheme only
+  - inline/eval -> `inline` / `eval` 等のbrowser token
+
+出力しない情報:
+
+- complete document URL
+- query string / fragment
+- `sourceFile`
+- line / column
+- CSP `sample`
+- request / response body
+- cookie
+- token
+- Admin credential
+- connection string
+
+`CSP_OBSERVATION` logへ上記以外を追加しない。
+
+## Automatic Deploy Preview observation
+
+通常のDeploy Preview smokeは`pnpm test:e2e`を実行するため、CSP observation specもChromium / mobile WebKitで実行される。
+
+期待される動作:
+
+1. `/`, `/about`, `/works`, `/blog`, `/news`, `/schedule`, `/links`, `/contact`をread-onlyで表示する。
+2. `/admin` login / create-first-user surfaceをread-onlyで表示する。
+3. `securitypolicyviolation` eventを収集する。
+4. sanitized inventoryだけを`CSP_OBSERVATION`として標準出力する。
+5. `/api/works?limit=1&depth=0`が200かつReport-Onlyのままであることを確認する。
+6. `Content-Security-Policy` enforcing headerが誤って追加されていた場合はfailする。
+
+violationが存在すること自体ではfailしない。Issue #29のPhase Bではviolationが観測対象だからである。
+
+## Production public / login-surface observation
+
+Productionへの観測も同じspecを使用する。read-only public routesと`/admin` login surfaceにはcredential不要。
+
+PowerShell:
+
+```powershell
+$env:E2E_BASE_URL="https://ivmz.ivrm.jp"
+pnpm test:csp-observe
+Remove-Item Env:E2E_BASE_URL
+```
+
+この実行はProductionへwriteしない。
+
+## Authenticated Payload Admin observation
+
+Authenticated Adminは自動credential入力を行わない。
+
+必要な場合だけ、開発者自身がローカルbrowserでloginし、Playwright storage stateを**Repository checkout外の一時ファイル**へ保存する。
+
+PowerShell例:
+
+```powershell
+$state = Join-Path $env:TEMP "ivmz-home-csp-admin-state.json"
+pnpm exec playwright codegen --save-storage="$state" https://ivmz.ivrm.jp/admin
+
+$env:E2E_BASE_URL="https://ivmz.ivrm.jp"
+$env:CSP_ADMIN_STORAGE_STATE=$state
+pnpm test:csp-observe
+
+Remove-Item $state -Force
+Remove-Item Env:CSP_ADMIN_STORAGE_STATE
+Remove-Item Env:E2E_BASE_URL
+```
+
+制約:
+
+- login passwordをscript / shell history / GitHub / Notionへ記載しない
+- storage stateをRepository配下へ保存しない
+- storage stateをCI artifactへuploadしない
+- observation完了後に一時stateを削除する
+- authenticated observationはread-only route navigationだけにする
+- create/update/delete操作はIssue #29 observationでは行わない
+
+現在のread-only authenticated routes:
+
+```text
+/admin
+/admin/collections/works
+/admin/collections/posts
+```
+
+## Inventory classification
+
+観測した各violationを以下へ分類する。
+
+### Next.js framework requirement
+
+Next.js / React runtime、framework bundle、framework inline script/style等。
+
+### Payload Admin requirement
+
+Payload Admin UI、Payloadが必要とするscript/style/image/font/connect等。
+
+### Application requirement
+
+`ivmz-home`固有のpublic UI、remote image、API接続等。
+
+### Third-party requirement
+
+外部サービスorigin。実際に必要である証拠があるものだけ候補へ残す。
+
+### Unnecessary / suspicious
+
+不要なextension injection、browser addon、unexpected external resource等。allowlistへ追加しない。
+
+## Enforcement design candidates
+
+### Candidate A — nonce-based CSP
+
+Next.js公式はrequestごとのnonceをCSP headerへ入れるstrict CSPをサポートし、framework scripts / page bundles / Next.js-generated inline script/styleへnonceを自動適用する。
+
+ただしnonce-based CSPはdynamic renderingが必要で、公式documentation上:
+
+- static optimization無効
+- ISR無効
+- default CDN caching不可
+- PPR非互換
+- requestごとのSSR負荷増
+
+となる。
+
+そのためpublic site全体へのnonce一括導入は、観測前には採用しない。
+
+### Candidate B — SRI / hash-based CSP
+
+Next.jsにはSRIによるhash-based CSP supportがあるが、現時点ではexperimentalでApp Router + webpack限定。
+
+`ivmz-home`はNext.js 16系で、Next.js 16は`next build`のdefault bundlerがTurbopackである。SRIを採用するにはwebpackへopt-outする必要があり、build pipeline / deploy behaviorの変更を伴う。
+
+したがってSRIも観測前には採用しない。
+
+### Candidate C — public / Admin policy separation
+
+実観測でPayload Adminだけに追加requirementが集中する場合、public routesと`/admin`でpolicyを分離する価値を評価する。
+
+狙い:
+
+- public static / cache behaviorを維持する
+- Admin側だけstrict nonce等を検討する
+- Payload固有allowlistをpublic siteへ拡散しない
+
+ただしNext.js / Netlifyのrequest path、header propagation、Payload Admin renderingで実際に成立することをDeploy Previewで検証してから採用する。
+
+## Prohibited shortcuts
+
+以下は観測結果なしでは採用しない。
+
+- `unsafe-inline`
+- `unsafe-eval`
+- `https:` scheme-wide allow
+- `*`
+- broad wildcard subdomain
+- policyを通すためだけのallowlist追加
+- Productionへのdirect enforce
+
+## Phase B completion gate
+
+次を満たしてからenforcement candidate実装へ進む。
+
+- Chromium Deploy Preview inventory
+- mobile WebKit Deploy Preview inventory
+- Production public/login-surface inventory
+- authenticated Admin inventory
+- framework / Payload / application / third-party分類
+- required origin / inline requirementに証拠がある
+- unnecessary sourceをallowlistへ含めない
+- rendering / cache impactを候補ごとに記録する
+
+## Official references
+
+- Next.js CSP: https://nextjs.org/docs/app/guides/content-security-policy
+- Next.js 16 upgrade / Turbopack default: https://nextjs.org/docs/app/guides/upgrading/version-16
+- Payload Admin overview: https://payloadcms.com/docs/admin/overview
+- Payload production deployment: https://payloadcms.com/docs/production/deployment
+- Netlify CSP: https://docs.netlify.com/manage/security/content-security-policy/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",
-    "format:check": "prettier --write tests/e2e/csp-observation.spec.ts && git diff --exit-code -- tests/e2e/csp-observation.spec.ts",
+    "format:check": "prettier --check .",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "next build",
     "start": "next start",
     "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format:check": "prettier --write tests/e2e/csp-observation.spec.ts && git diff --exit-code -- tests/e2e/csp-observation.spec.ts",
     "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:csp-observe": "playwright test tests/e2e/csp-observation.spec.ts --reporter=line",
     "payload": "cross-env NODE_OPTIONS=--no-deprecation PAYLOAD_CONFIG_PATH=src/payload.config.ts payload",
     "generate:types": "pnpm payload generate:types",
     "generate:importmap": "pnpm payload generate:importmap",

--- a/tests/e2e/csp-observation.spec.ts
+++ b/tests/e2e/csp-observation.spec.ts
@@ -111,6 +111,8 @@ async function observeRoute(page: Page, route: string, testInfo: TestInfo) {
     await page.evaluate(() => (window as ObservationWindow).__ivmzCspViolations ?? []),
   )
 
+  // Exact-head Preview Smoke logs are the short-lived observation source.
+  // Only this sanitized inventory may be summarized into long-lived Issue/PR documentation.
   // Intentionally emit only sanitized fields. Do not add documentURI, sourceFile,
   // line/column, sample, request bodies, cookies, tokens, or query strings here.
   console.info(

--- a/tests/e2e/csp-observation.spec.ts
+++ b/tests/e2e/csp-observation.spec.ts
@@ -88,8 +88,6 @@ async function installCspObserver(page: Page) {
 }
 
 async function observeRoute(page: Page, route: string, testInfo: TestInfo) {
-  await installCspObserver(page)
-
   const response = await page.goto(route, { waitUntil: 'domcontentloaded' })
   expect(response, `${route}: navigation response`).not.toBeNull()
 
@@ -98,8 +96,14 @@ async function observeRoute(page: Page, route: string, testInfo: TestInfo) {
   expect(response.status(), `${route}: status`).toBeLessThan(500)
 
   const headers = response.headers()
-  expect(headers['content-security-policy-report-only'], `${route}: Report-Only header`).toBeTruthy()
-  expect(headers['content-security-policy'], `${route}: enforcing CSP must stay disabled`).toBeUndefined()
+  expect(
+    headers['content-security-policy-report-only'],
+    `${route}: Report-Only header`,
+  ).toBeTruthy()
+  expect(
+    headers['content-security-policy'],
+    `${route}: enforcing CSP must stay disabled`,
+  ).toBeUndefined()
 
   await page.waitForTimeout(1_000)
 
@@ -122,46 +126,53 @@ test.describe('CSP Report-Only observation', () => {
   test('public routes and Payload Admin login surface expose sanitized violations only', async ({
     page,
   }, testInfo) => {
+    await installCspObserver(page)
+
     for (const route of publicObservationRoutes) {
       await observeRoute(page, route, testInfo)
     }
   })
 
-  test('Payload public API remains Report-Only and is not accidentally enforced', async ({ request }) => {
-    const response = await request.get('/api/works?limit=1&depth=0')
-    expect(response.status()).toBe(200)
+  test(
+    'Payload public API remains Report-Only and is not accidentally enforced',
+    async ({ request }) => {
+      const response = await request.get('/api/works?limit=1&depth=0')
+      expect(response.status()).toBe(200)
 
-    const headers = response.headers()
-    expect(headers['content-security-policy-report-only']).toBeTruthy()
-    expect(headers['content-security-policy']).toBeUndefined()
-  })
+      const headers = response.headers()
+      expect(headers['content-security-policy-report-only']).toBeTruthy()
+      expect(headers['content-security-policy']).toBeUndefined()
+    },
+  )
 
-  test('authenticated Payload Admin observation is explicit local opt-in and read-only', async ({
-    browser,
-  }, testInfo) => {
-    const storageState = process.env.CSP_ADMIN_STORAGE_STATE
-    test.skip(
-      !storageState,
-      'Set CSP_ADMIN_STORAGE_STATE to a local, untracked Playwright storage-state file to observe authenticated Admin routes.',
-    )
+  test(
+    'authenticated Payload Admin observation is explicit local opt-in and read-only',
+    async ({ browser }, testInfo) => {
+      const storageState = process.env.CSP_ADMIN_STORAGE_STATE
+      test.skip(
+        !storageState,
+        'Set CSP_ADMIN_STORAGE_STATE to a local, untracked Playwright storage-state file to observe authenticated Admin routes.',
+      )
 
-    const baseURL = process.env.E2E_BASE_URL
-    if (!baseURL) {
-      throw new Error('E2E_BASE_URL is required when CSP_ADMIN_STORAGE_STATE is set.')
-    }
-
-    const context = await browser.newContext({
-      baseURL,
-      storageState,
-    })
-    const page = await context.newPage()
-
-    try {
-      for (const route of authenticatedAdminRoutes) {
-        await observeRoute(page, route, testInfo)
+      const baseURL = process.env.E2E_BASE_URL
+      if (!baseURL) {
+        throw new Error('E2E_BASE_URL is required when CSP_ADMIN_STORAGE_STATE is set.')
       }
-    } finally {
-      await context.close()
-    }
-  })
+
+      const context = await browser.newContext({
+        baseURL,
+        storageState,
+      })
+      const page = await context.newPage()
+      await installCspObserver(page)
+
+      try {
+        for (const route of authenticatedAdminRoutes) {
+          await observeRoute(page, route, testInfo)
+        }
+      } finally {
+        await context.close()
+      }
+    },
+  )
 })

--- a/tests/e2e/csp-observation.spec.ts
+++ b/tests/e2e/csp-observation.spec.ts
@@ -123,57 +123,54 @@ async function observeRoute(page: Page, route: string, testInfo: TestInfo) {
 }
 
 test.describe('CSP Report-Only observation', () => {
-  test(
-    'public routes and Payload Admin login surface expose sanitized violations only',
-    async ({ page }, testInfo) => {
-      await installCspObserver(page)
+  test('public routes and Payload Admin login surface expose sanitized violations only', async ({
+    page,
+  }, testInfo) => {
+    await installCspObserver(page)
 
-      for (const route of publicObservationRoutes) {
+    for (const route of publicObservationRoutes) {
+      await observeRoute(page, route, testInfo)
+    }
+  })
+
+  test('Payload public API remains Report-Only and is not accidentally enforced', async ({
+    request,
+  }) => {
+    const response = await request.get('/api/works?limit=1&depth=0')
+    expect(response.status()).toBe(200)
+
+    const headers = response.headers()
+    expect(headers['content-security-policy-report-only']).toBeTruthy()
+    expect(headers['content-security-policy']).toBeUndefined()
+  })
+
+  test('authenticated Payload Admin observation is explicit local opt-in and read-only', async ({
+    browser,
+  }, testInfo) => {
+    const storageState = process.env.CSP_ADMIN_STORAGE_STATE
+    test.skip(
+      !storageState,
+      'Set CSP_ADMIN_STORAGE_STATE to a local, untracked Playwright storage-state file to observe authenticated Admin routes.',
+    )
+
+    const baseURL = process.env.E2E_BASE_URL
+    if (!baseURL) {
+      throw new Error('E2E_BASE_URL is required when CSP_ADMIN_STORAGE_STATE is set.')
+    }
+
+    const context = await browser.newContext({
+      baseURL,
+      storageState,
+    })
+    const page = await context.newPage()
+    await installCspObserver(page)
+
+    try {
+      for (const route of authenticatedAdminRoutes) {
         await observeRoute(page, route, testInfo)
       }
-    },
-  )
-
-  test(
-    'Payload public API remains Report-Only and is not accidentally enforced',
-    async ({ request }) => {
-      const response = await request.get('/api/works?limit=1&depth=0')
-      expect(response.status()).toBe(200)
-
-      const headers = response.headers()
-      expect(headers['content-security-policy-report-only']).toBeTruthy()
-      expect(headers['content-security-policy']).toBeUndefined()
-    },
-  )
-
-  test(
-    'authenticated Payload Admin observation is explicit local opt-in and read-only',
-    async ({ browser }, testInfo) => {
-      const storageState = process.env.CSP_ADMIN_STORAGE_STATE
-      test.skip(
-        !storageState,
-        'Set CSP_ADMIN_STORAGE_STATE to a local, untracked Playwright storage-state file to observe authenticated Admin routes.',
-      )
-
-      const baseURL = process.env.E2E_BASE_URL
-      if (!baseURL) {
-        throw new Error('E2E_BASE_URL is required when CSP_ADMIN_STORAGE_STATE is set.')
-      }
-
-      const context = await browser.newContext({
-        baseURL,
-        storageState,
-      })
-      const page = await context.newPage()
-      await installCspObserver(page)
-
-      try {
-        for (const route of authenticatedAdminRoutes) {
-          await observeRoute(page, route, testInfo)
-        }
-      } finally {
-        await context.close()
-      }
-    },
-  )
+    } finally {
+      await context.close()
+    }
+  })
 })

--- a/tests/e2e/csp-observation.spec.ts
+++ b/tests/e2e/csp-observation.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page, type TestInfo } from '@playwright/test'
+
+type SanitizedCspViolation = {
+  blocked: string
+  disposition: string
+  effectiveDirective: string
+  violatedDirective: string
+}
+
+type ObservationWindow = Window & {
+  __ivmzCspViolations?: SanitizedCspViolation[]
+}
+
+const publicObservationRoutes = [
+  '/',
+  '/about',
+  '/works',
+  '/blog',
+  '/news',
+  '/schedule',
+  '/links',
+  '/contact',
+  '/admin',
+] as const
+
+const authenticatedAdminRoutes = [
+  '/admin',
+  '/admin/collections/works',
+  '/admin/collections/posts',
+] as const
+
+function dedupeViolations(violations: SanitizedCspViolation[]) {
+  const unique = new Map<string, SanitizedCspViolation>()
+
+  for (const violation of violations) {
+    const key = [
+      violation.effectiveDirective,
+      violation.violatedDirective,
+      violation.disposition,
+      violation.blocked,
+    ].join('|')
+    unique.set(key, violation)
+  }
+
+  return [...unique.values()].sort((left, right) =>
+    `${left.effectiveDirective}|${left.blocked}`.localeCompare(
+      `${right.effectiveDirective}|${right.blocked}`,
+    ),
+  )
+}
+
+async function installCspObserver(page: Page) {
+  await page.addInitScript(() => {
+    const observationWindow = window as ObservationWindow
+    observationWindow.__ivmzCspViolations = []
+
+    const sanitizeBlockedUri = (blockedUri: string, documentUri: string) => {
+      const value = blockedUri.trim()
+      if (!value) return 'unknown'
+
+      if (['inline', 'eval', 'wasm-eval', 'trusted-types-sink'].includes(value)) {
+        return value
+      }
+
+      if (value === 'self') return "'self'"
+      if (value.startsWith('data:')) return 'data:'
+      if (value.startsWith('blob:')) return 'blob:'
+
+      try {
+        const blocked = new URL(value, documentUri)
+        const documentUrl = new URL(documentUri)
+        return blocked.origin === documentUrl.origin ? "'self'" : blocked.origin
+      } catch {
+        const scheme = value.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]
+        return scheme ? `${scheme.toLowerCase()}:` : 'opaque'
+      }
+    }
+
+    window.addEventListener('securitypolicyviolation', (event) => {
+      observationWindow.__ivmzCspViolations?.push({
+        blocked: sanitizeBlockedUri(event.blockedURI, event.documentURI),
+        disposition: event.disposition,
+        effectiveDirective: event.effectiveDirective,
+        violatedDirective: event.violatedDirective,
+      })
+    })
+  })
+}
+
+async function observeRoute(page: Page, route: string, testInfo: TestInfo) {
+  await installCspObserver(page)
+
+  const response = await page.goto(route, { waitUntil: 'domcontentloaded' })
+  expect(response, `${route}: navigation response`).not.toBeNull()
+
+  if (!response) return
+
+  expect(response.status(), `${route}: status`).toBeLessThan(500)
+
+  const headers = response.headers()
+  expect(headers['content-security-policy-report-only'], `${route}: Report-Only header`).toBeTruthy()
+  expect(headers['content-security-policy'], `${route}: enforcing CSP must stay disabled`).toBeUndefined()
+
+  await page.waitForTimeout(1_000)
+
+  const violations = dedupeViolations(
+    await page.evaluate(() => (window as ObservationWindow).__ivmzCspViolations ?? []),
+  )
+
+  // Intentionally emit only sanitized fields. Do not add documentURI, sourceFile,
+  // line/column, sample, request bodies, cookies, tokens, or query strings here.
+  console.info(
+    `CSP_OBSERVATION ${JSON.stringify({
+      project: testInfo.project.name,
+      route,
+      violations,
+    })}`,
+  )
+}
+
+test.describe('CSP Report-Only observation', () => {
+  test('public routes and Payload Admin login surface expose sanitized violations only', async ({
+    page,
+  }, testInfo) => {
+    for (const route of publicObservationRoutes) {
+      await observeRoute(page, route, testInfo)
+    }
+  })
+
+  test('Payload public API remains Report-Only and is not accidentally enforced', async ({ request }) => {
+    const response = await request.get('/api/works?limit=1&depth=0')
+    expect(response.status()).toBe(200)
+
+    const headers = response.headers()
+    expect(headers['content-security-policy-report-only']).toBeTruthy()
+    expect(headers['content-security-policy']).toBeUndefined()
+  })
+
+  test('authenticated Payload Admin observation is explicit local opt-in and read-only', async ({
+    browser,
+  }, testInfo) => {
+    const storageState = process.env.CSP_ADMIN_STORAGE_STATE
+    test.skip(
+      !storageState,
+      'Set CSP_ADMIN_STORAGE_STATE to a local, untracked Playwright storage-state file to observe authenticated Admin routes.',
+    )
+
+    const baseURL = process.env.E2E_BASE_URL
+    if (!baseURL) {
+      throw new Error('E2E_BASE_URL is required when CSP_ADMIN_STORAGE_STATE is set.')
+    }
+
+    const context = await browser.newContext({
+      baseURL,
+      storageState,
+    })
+    const page = await context.newPage()
+
+    try {
+      for (const route of authenticatedAdminRoutes) {
+        await observeRoute(page, route, testInfo)
+      }
+    } finally {
+      await context.close()
+    }
+  })
+})

--- a/tests/e2e/csp-observation.spec.ts
+++ b/tests/e2e/csp-observation.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page, type TestInfo } from '@playwright/test'
+import { expect, test, type Page, type Response, type TestInfo } from '@playwright/test'
 
 type SanitizedCspViolation = {
   blocked: string
@@ -29,6 +29,9 @@ const authenticatedAdminRoutes = [
   '/admin/collections/posts',
 ] as const
 
+const remoteObservationAttempts = process.env.E2E_BASE_URL ? 2 : 1
+const remoteObservationTimeoutMs = process.env.E2E_BASE_URL ? 20_000 : undefined
+
 function dedupeViolations(violations: SanitizedCspViolation[]) {
   const unique = new Map<string, SanitizedCspViolation>()
 
@@ -47,6 +50,41 @@ function dedupeViolations(violations: SanitizedCspViolation[]) {
       `${right.effectiveDirective}|${right.blocked}`,
     ),
   )
+}
+
+function isTransientNavigationError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error)
+  return /net::ERR_|NS_ERROR_|navigation.*interrupted|page\.goto: Timeout|Timeout \d+ms exceeded/i.test(
+    message,
+  )
+}
+
+async function gotoObservation(page: Page, route: string): Promise<Response | null> {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= remoteObservationAttempts; attempt += 1) {
+    try {
+      return await page.goto(route, {
+        waitUntil: 'domcontentloaded',
+        timeout: remoteObservationTimeoutMs,
+      })
+    } catch (error) {
+      lastError = error
+
+      if (attempt === remoteObservationAttempts || !isTransientNavigationError(error)) {
+        throw error
+      }
+
+      // Keep retry diagnostics privacy-safe: route labels are fixed constants and
+      // no URL, response body, request ID, cookie, token, or credential is emitted.
+      console.info(`CSP_NAVIGATION_RETRY ${JSON.stringify({ route, attempt })}`)
+      await page.waitForTimeout(250)
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('CSP observation navigation failed without an Error object.')
 }
 
 async function installCspObserver(page: Page) {
@@ -88,7 +126,7 @@ async function installCspObserver(page: Page) {
 }
 
 async function observeRoute(page: Page, route: string, testInfo: TestInfo) {
-  const response = await page.goto(route, { waitUntil: 'domcontentloaded' })
+  const response = await gotoObservation(page, route)
   expect(response, `${route}: navigation response`).not.toBeNull()
 
   if (!response) return
@@ -128,6 +166,10 @@ test.describe('CSP Report-Only observation', () => {
   test('public routes and Payload Admin login surface expose sanitized violations only', async ({
     page,
   }, testInfo) => {
+    if (process.env.E2E_BASE_URL) {
+      testInfo.setTimeout(90_000)
+    }
+
     await installCspObserver(page)
 
     for (const route of publicObservationRoutes) {
@@ -159,6 +201,8 @@ test.describe('CSP Report-Only observation', () => {
     if (!baseURL) {
       throw new Error('E2E_BASE_URL is required when CSP_ADMIN_STORAGE_STATE is set.')
     }
+
+    testInfo.setTimeout(60_000)
 
     const context = await browser.newContext({
       baseURL,

--- a/tests/e2e/csp-observation.spec.ts
+++ b/tests/e2e/csp-observation.spec.ts
@@ -123,15 +123,16 @@ async function observeRoute(page: Page, route: string, testInfo: TestInfo) {
 }
 
 test.describe('CSP Report-Only observation', () => {
-  test('public routes and Payload Admin login surface expose sanitized violations only', async ({
-    page,
-  }, testInfo) => {
-    await installCspObserver(page)
+  test(
+    'public routes and Payload Admin login surface expose sanitized violations only',
+    async ({ page }, testInfo) => {
+      await installCspObserver(page)
 
-    for (const route of publicObservationRoutes) {
-      await observeRoute(page, route, testInfo)
-    }
-  })
+      for (const route of publicObservationRoutes) {
+        await observeRoute(page, route, testInfo)
+      }
+    },
+  )
 
   test(
     'Payload public API remains Report-Only and is not accidentally enforced',


### PR DESCRIPTION
## Summary

Issue #29 Phase A/Bとして、ProductionのCSPを変更せずにreal `Content-Security-Policy-Report-Only` violationを観測するsecret-free Playwright harnessとRunbookを追加します。

Refs #29

## Changes

- `tests/e2e/csp-observation.spec.ts`
  - public routes + `/admin` login surfaceをread-only観測
  - browser `securitypolicyviolation` eventを収集
  - full URL / query / sample / sourceFile / cookie / token / credentialは出力しない
  - external blocked resourceはoriginまで、same-originは `'self'`、`data:` / `blob:`はschemeだけへsanitize
  - enforcing `Content-Security-Policy`が意図せず追加された場合はfail
  - remote observation navigationだけ既知の一時的transport/navigation failureを最大1回retry
  - HTTP/CSP assertion自体はretryしない
  - `/api/works`がReport-Onlyのままであることを確認
  - authenticated Adminはlocal untracked storage-stateを明示指定した場合だけread-only観測
- `package.json`
  - `pnpm test:csp-observe`
- `docs/csp-observation.md`
  - observation data minimization
  - Deploy Preview / Production observation手順
  - Deploy Preview violation inventory
  - authenticated Adminの一時storage-state運用
  - nonce / SRI / public-vs-Admin policy分離のcandidate整理

## Security decisions

- Production CSPはReport-Onlyのまま
- Production report collector / debug endpointは追加しない
- `unsafe-inline` / `unsafe-eval` / wildcard / scheme-wide allowは追加しない
- Netlify Deploy Preview固有sourceをProduction allowlistへ昇格しない
- Production `PAYLOAD_SECRET`は変更しない
- Production DB / Preview DBは変更しない
- Production mutationは行わない

## Deploy Preview observation

Final exact-head `b442902feafc4c0f30b70a40ad3f2c8c2046a889`:

- CI #344: GREEN
- Netlify Preview Smoke #312: GREEN
- Playwright: 51 passed / 8 skipped
- Chromium / mobile WebKit CSP inventory: consistent
- Payload public API preflight: GREEN
- Payload auth rate-limit: 429 observed at attempt 17
- enforcing `Content-Security-Policy`: not introduced
- CSP stays Report-Only
- CSP observation-specific `CSP_NAVIGATION_RETRY`: not emitted in final run

Sanitized inventory:

- public routes: `script-src-elem` / `inline`
- public routes: `style-src-attr` / `inline`
- `/admin`: above + `style-src-elem` / `inline`
- Preview environment: `frame-src` / `https://app.netlify.com`
- `unsafe-eval` requirement: not observed
- no evidence from Preview that Production needs additional external `script` / `img` / `font` / `connect` / `worker` origins

`https://app.netlify.com`はDeploy Preview環境由来として扱い、Production allowlistへ昇格しません。

`/admin`だけ追加style requirementがあるため、public / Admin policy separationは有力candidateとして残します。ただしauthenticated Admin operation観測前には確定しません。

## Current architecture finding

- Next.js `16.3.3`
- Payload `3.88.0`
- nonce CSPはNext.js公式上dynamic rendering必須で、static optimization / ISR / default CDN caching / PPRへ影響
- SRIは公式情報に不整合がある
  - current CSP/Turbopack docsは`experimental.sri`をwebpack-only / Turbopack未対応と記載
  - Next.js 16.2 release notesはTurbopackのJavaScript SRI supportを明記
- webpack opt-outの要否は断定せず、exact `16.3.3` + Netlify Preview spikeで実測する
- SRIはexternal JavaScript integrityであり、今回実観測したinline script/style requirementを単独では解決しない前提で評価する

## Validation gates

### Gate 1 — quality ✅

Final head CI #344 GREEN:

- format check
- lint
- typecheck
- unit tests
- Payload migration / generated artifacts
- build

### Gate 2 — final exact-head Deploy Preview ✅

Preview Smoke #312 GREEN:

- Chromium / mobile WebKit existing E2E
- CSP sanitized inventory
- public + `/admin` login surface
- Payload public API
- auth rate-limit 429
- security regression

### Gate 3 — Production / authenticated Admin observation ⏳

Remaining:

- Production public/login-surfaceを`pnpm test:csp-observe`でread-only観測
- authenticated Adminはcredentialをcode/logへ入れず、Repository外の一時storage-stateだけを使用してread-only観測
- authenticated Admin operationを含むinventoryをNext.js / Payload / application / third-partyへ最終分類
- exact Next.js 16.3.3 SRI/Turbopack behaviorをseparate Preview spikeで確認

Current execution environmentからProduction hostはDNS解決できなかったため、collector/debug endpointを追加する代替は採用していません。

Production enforcementはこのPRでは行いません。enforcement candidateはinventory確定後に別PR・別承認とします。