### PR TITLE
docs(ops): document Production Git sync recovery

### DIFF
--- a/docs/netlify-production-sync.md
+++ b/docs/netlify-production-sync.md
@@ -17,12 +17,12 @@ Do not use a manual/API Production deploy merely to hide commit drift. `main` is
 
 ## Verified incident snapshot
 
-At the 2026-08-29 recheck:
+Latest recheck:
 
 - GitHub `main`: `f99ec389a098477b46d37136aa7339b52b30c17a`
 - latest main CI: #345 / success
-- Netlify Production branch: `main`
 - Netlify current Production deploy: `6a91749fbb00070008ddaf51`
+- Netlify current Production deploy branch metadata: `main`
 - Netlify current Production commit: `7377189dcae4b67ea87f9e00058be42666db0619`
 - Netlify current Production state: `ready`
 - current Production deploy is not a manual deploy
@@ -31,35 +31,53 @@ At the 2026-08-29 recheck:
 
 The Production deploy is therefore healthy but stale relative to the current GitHub `main` after PR #34.
 
-Repository-side suppression was also checked:
+Repository-side suppression was checked:
 
 - PR #34 title and merge commit do not contain `[skip netlify]` or `[skip ci]`
 - `netlify.toml` does not define a Production ignore/skip rule
-- Production branch remains intended to be `main`
+- intended Production branch remains `main`
+
+## Diagnostic PR result
+
+Draft PR #39 was created from the exact current `main` to determine whether GitHub/Netlify integration and builds are globally broken.
+
+Validated diagnostic head before this runbook refresh:
+
+- commit: `e15bfd354e84d68975899fcccdcb1a9c370b1665`
+- Netlify Deploy Preview: exact-head / `ready`
+- `netlify/ivmz-home/deploy-preview`: success
+- CI #346: success
+- Netlify Preview Smoke #313: success
+- Payload public API preflight: success
+- Chromium / mobile WebKit Playwright smoke: success
+- Payload auth rate-limit 429 verification: success
+- Deploy Preview secret scan: zero matches
+
+This rules out:
+
+- a global stopped-builds state
+- a complete GitHub/Netlify integration disconnect
+- a general inability for Netlify to build the current repository
+
+The remaining failure domain is Production-path-specific.
 
 ## Root-cause decision tree
 
 ### 1. Confirm builds are active
 
+The successful exact-head Deploy Preview from PR #39 proves builds are currently active for the project. Do not treat global stopped builds as the primary hypothesis unless a later PR also stops producing previews.
+
+### 2. Confirm configured Production branch
+
 In Netlify:
-
-`Project configuration -> Build & deploy -> Continuous deployment -> Build settings`
-
-Expected:
-
-- Build status: `Active builds`
-
-If builds are stopped, activate builds before doing anything else. Activating builds alone does not create a new deploy; the next approved Git event must trigger the build.
-
-### 2. Confirm Production branch
-
-In:
 
 `Project configuration -> Build & deploy -> Continuous deployment -> Branches and deploy contexts`
 
 Expected:
 
 - Production branch: `main`
+
+Do not infer this setting only from the old Production deploy metadata reporting `branch=main`. Verify the current project configuration.
 
 Do not temporarily point Production at a feature branch to work around the incident.
 
@@ -69,6 +87,8 @@ On the Netlify Deploys page, verify the site is not locked and auto publishing i
 
 A locked deploy may allow newer Production builds to exist without making them the live deploy. If a newer `main` deploy exists but is unpublished, investigate why the lock was enabled before unlocking it.
 
+The currently live deploy reports `locked=null`; this does not by itself prove the current project-level auto-publish control is enabled.
+
 ### 4. Inspect the exact current-main commit
 
 Search the Production deploy history for:
@@ -77,7 +97,7 @@ Search the Production deploy history for:
 
 Classify the result:
 
-- no deploy exists -> investigate GitHub App / repository integration event delivery
+- no deploy exists -> investigate Production `main` push event delivery / Production branch trigger
 - failed deploy -> inspect build logs and fix the actual failure
 - skipped deploy -> inspect skip reason / build configuration
 - ready but unpublished -> inspect auto-publish lock
@@ -85,25 +105,32 @@ Classify the result:
 
 Do not copy secrets, environment values, contact data, or authenticated state into the incident record.
 
-### 5. Confirm Git integration
+### 5. Confirm Git integration target
 
 Verify the connected repository is still:
 
 `mizzz-ivr/ivmz-home`
 
-If the repository connection is broken, restore the Git integration without weakening `Enforce Git-based deployments`.
+PR #39 proves current PR events can reach Netlify, but the Production branch trigger / publish path still needs separate validation.
 
-## Diagnostic PR behavior
+If configuration evidence shows the repository connection is inconsistent, restore the Git integration without weakening `Enforce Git-based deployments`.
 
-This runbook change is intentionally a docs-only Draft PR created from the exact stale-gap `main` head.
+## Connected-tool boundary
 
-Its Deploy Preview is a non-Production diagnostic signal:
+The currently connected Netlify surface can:
 
-- Deploy Preview created successfully -> Netlify can still receive/build current PR Git events; investigate Production branch / auto-publish behavior specifically
-- no Deploy Preview and no Netlify check -> investigate stopped builds or broken Git integration globally
-- Deploy Preview fails -> inspect the failure without weakening required checks
+- read the project and current deploy
+- read a known deploy by ID
+- trigger a deployment
 
-The PR must not be merged only to force a Production deploy. Merge remains subject to the normal review and explicit owner approval policy.
+It does not expose:
+
+- configured Production branch controls
+- project-level auto-publish / deploy-lock controls
+- complete Production deploy-history search by commit
+- Git repository-binding configuration
+
+Because the available deployment trigger would create a direct/manual deployment path, it must not be used for Issue #38. The remaining Production-path configuration checks require an authorized Netlify configuration surface that exposes these controls.
 
 ## Recovery acceptance
 
@@ -112,20 +139,23 @@ Issue #38 can be completed only when all of the following are true:
 1. GitHub `main` HEAD is reconfirmed immediately before acceptance.
 2. latest main CI is success.
 3. Netlify current Production `commit_ref` equals that exact `main` HEAD.
-4. Production state is `ready`.
-5. Next.js Netlify plugin state is success.
-6. secret scan has zero matches.
-7. public read-only smoke is healthy.
-8. Payload published read remains healthy.
-9. Production CSP remains Report-Only until Issue #29 explicitly advances enforcement.
-10. the root cause and recovery action are recorded without exposing secrets.
+4. configured Production branch is `main`.
+5. Production state is `ready`.
+6. Next.js Netlify plugin state is success.
+7. secret scan has zero matches.
+8. deployment came from the approved Git integration path.
+9. public read-only smoke is healthy.
+10. Payload published read remains healthy.
+11. Production CSP remains Report-Only until Issue #29 explicitly advances enforcement.
+12. the root cause and recovery action are recorded without exposing secrets.
 
 ## Guardrails
 
 - do not disable `Enforce Git-based deployments`
 - do not bypass GitHub `Protect main`
 - do not direct-push to `main`
-- do not use a manual/API Production deploy to conceal drift
+- do not use a manual/API/MCP Production deploy to conceal drift
+- do not merge diagnostic PR #39 merely to generate a Production build
 - do not rotate `PAYLOAD_SECRET` as part of this incident
 - do not modify Production database data
 - do not weaken Deploy Preview, CI, security, or secret-scanning checks

--- a/docs/netlify-production-sync.md
+++ b/docs/netlify-production-sync.md
@@ -41,28 +41,19 @@ Repository-side suppression was checked:
 
 Draft PR #39 was created from the exact current `main` to determine whether GitHub/Netlify integration and builds are globally broken.
 
-Validated first diagnostic head:
+Final validated diagnostic head:
 
-- commit: `e15bfd354e84d68975899fcccdcb1a9c370b1665`
+- commit: `53998ecfcae54f64c2e9d68b65693d9bc714a4f2`
+- CI #348: success
 - Netlify Deploy Preview: exact-head / `ready`
-- `netlify/ivmz-home/deploy-preview`: success
-- CI #346: success
-- Netlify Preview Smoke #313: success
+- Netlify plugin state: success
+- Deploy Preview secret scan: zero matches
+- Netlify Preview Smoke #315: success
 - Payload public API preflight: success
 - Chromium / mobile WebKit Playwright smoke: success
 - Payload auth rate-limit 429 verification: success
-- Deploy Preview secret scan: zero matches
 
-Current runbook-refresh head:
-
-- commit: `bcd17d63903ce484d8d149284b246c4ec96b532c`
-- CI #347: success
-- exact-head Netlify Deploy Preview: `ready`
-- Netlify plugin state: success
-- Deploy Preview secret scan: zero matches / 214 files
-- Netlify Preview Smoke #314: running at the time of this documentation refresh
-
-This rules out:
+Earlier diagnostic heads also produced healthy exact-head previews. This repeated result rules out:
 
 - a global stopped-builds state
 - a complete GitHub/Netlify integration disconnect

--- a/docs/netlify-production-sync.md
+++ b/docs/netlify-production-sync.md
@@ -41,7 +41,7 @@ Repository-side suppression was checked:
 
 Draft PR #39 was created from the exact current `main` to determine whether GitHub/Netlify integration and builds are globally broken.
 
-Validated diagnostic head before this runbook refresh:
+Validated first diagnostic head:
 
 - commit: `e15bfd354e84d68975899fcccdcb1a9c370b1665`
 - Netlify Deploy Preview: exact-head / `ready`
@@ -52,6 +52,15 @@ Validated diagnostic head before this runbook refresh:
 - Chromium / mobile WebKit Playwright smoke: success
 - Payload auth rate-limit 429 verification: success
 - Deploy Preview secret scan: zero matches
+
+Current runbook-refresh head:
+
+- commit: `bcd17d63903ce484d8d149284b246c4ec96b532c`
+- CI #347: success
+- exact-head Netlify Deploy Preview: `ready`
+- Netlify plugin state: success
+- Deploy Preview secret scan: zero matches / 214 files
+- Netlify Preview Smoke #314: running at the time of this documentation refresh
 
 This rules out:
 
@@ -65,7 +74,7 @@ The remaining failure domain is Production-path-specific.
 
 ### 1. Confirm builds are active
 
-The successful exact-head Deploy Preview from PR #39 proves builds are currently active for the project. Do not treat global stopped builds as the primary hypothesis unless a later PR also stops producing previews.
+The successful exact-head Deploy Previews from PR #39 prove builds are currently active for the project. Do not treat global stopped builds as the primary hypothesis unless a later PR also stops producing previews.
 
 ### 2. Confirm configured Production branch
 

--- a/docs/netlify-production-sync.md
+++ b/docs/netlify-production-sync.md
@@ -1,6 +1,6 @@
 # Netlify Production Git synchronization recovery
 
-Status: Issue #38 investigation — 2026-08-29
+Status: Issue #38 investigation — rechecked 2026-09-01
 
 ## Goal
 
@@ -17,7 +17,7 @@ Do not use a manual/API Production deploy merely to hide commit drift. `main` is
 
 ## Verified incident snapshot
 
-Latest recheck:
+Latest recheck on 2026-09-01:
 
 - GitHub `main`: `f99ec389a098477b46d37136aa7339b52b30c17a`
 - latest main CI: #345 / success
@@ -29,7 +29,7 @@ Latest recheck:
 - Production plugin state is success
 - Production secret scan reports zero matches
 
-The Production deploy is therefore healthy but stale relative to the current GitHub `main` after PR #34.
+The Production deploy is healthy but still stale relative to GitHub `main`; the billing/credit-cycle recovery did not retroactively create the missed Production deploy.
 
 Repository-side suppression was checked:
 
@@ -41,31 +41,41 @@ Repository-side suppression was checked:
 
 Draft PR #39 was created from the exact current `main` to determine whether GitHub/Netlify integration and builds are globally broken.
 
-Final validated diagnostic head:
+Last fully validated pre-recheck head:
 
-- commit: `53998ecfcae54f64c2e9d68b65693d9bc714a4f2`
-- CI #348: success
+- commit: `81f06cb0d1f06344f59c91eb22798cb8205f47d0`
+- CI #349: success
 - Netlify Deploy Preview: exact-head / `ready`
 - Netlify plugin state: success
-- Deploy Preview secret scan: zero matches
-- Netlify Preview Smoke #315: success
+- Deploy Preview secret scan: zero matches / 216 files
+- Netlify Preview Smoke #316: success
 - Payload public API preflight: success
 - Chromium / mobile WebKit Playwright smoke: success
 - Payload auth rate-limit 429 verification: success
 
 Earlier diagnostic heads also produced healthy exact-head previews. This repeated result rules out:
 
-- a global stopped-builds state
+- a global stopped-builds state at the time of those checks
 - a complete GitHub/Netlify integration disconnect
 - a general inability for Netlify to build the current repository
 
-The remaining failure domain is Production-path-specific.
+### 2026-09-01 credit-cycle probe
+
+This documentation-only update intentionally creates one new PR Git event after the expected credit-cycle recovery.
+
+Interpretation:
+
+- exact-head Deploy Preview builds successfully -> current Netlify build capacity is available again; proceed to a legitimate reviewed `main` Git event for Production-path validation
+- Preview is blocked by account/credit state -> pause deployment work until Netlify capacity is restored
+- Preview fails for a repository/build reason -> fix that actual failure first
+
+Do not add another docs-only commit merely to keep probing. After this probe, use its resulting CI / Deploy Preview / Preview Smoke as the final non-Production evidence.
 
 ## Root-cause decision tree
 
 ### 1. Confirm builds are active
 
-The successful exact-head Deploy Previews from PR #39 prove builds are currently active for the project. Do not treat global stopped builds as the primary hypothesis unless a later PR also stops producing previews.
+Healthy exact-head Deploy Previews prove builds are active for the project. If the 2026-09-01 probe also succeeds, current build capacity after the credit-cycle reset is confirmed.
 
 ### 2. Confirm configured Production branch
 
@@ -129,6 +139,7 @@ It does not expose:
 - project-level auto-publish / deploy-lock controls
 - complete Production deploy-history search by commit
 - Git repository-binding configuration
+- account credit balance / billing-cycle controls
 
 Because the available deployment trigger would create a direct/manual deployment path, it must not be used for Issue #38. The remaining Production-path configuration checks require an authorized Netlify configuration surface that exposes these controls.
 

--- a/docs/netlify-production-sync.md
+++ b/docs/netlify-production-sync.md
@@ -1,0 +1,131 @@
+# Netlify Production Git synchronization recovery
+
+Status: Issue #38 investigation — 2026-08-29
+
+## Goal
+
+Production release path remains:
+
+```text
+reviewed pull request
+  -> GitHub main
+  -> Netlify Git integration
+  -> Production
+```
+
+Do not use a manual/API Production deploy merely to hide commit drift. `main` is the release Source of Truth and Netlify Production must converge to its exact commit through the approved Git workflow.
+
+## Verified incident snapshot
+
+At the 2026-08-29 recheck:
+
+- GitHub `main`: `f99ec389a098477b46d37136aa7339b52b30c17a`
+- latest main CI: #345 / success
+- Netlify Production branch: `main`
+- Netlify current Production deploy: `6a91749fbb00070008ddaf51`
+- Netlify current Production commit: `7377189dcae4b67ea87f9e00058be42666db0619`
+- Netlify current Production state: `ready`
+- current Production deploy is not a manual deploy
+- Production plugin state is success
+- Production secret scan reports zero matches
+
+The Production deploy is therefore healthy but stale relative to the current GitHub `main` after PR #34.
+
+Repository-side suppression was also checked:
+
+- PR #34 title and merge commit do not contain `[skip netlify]` or `[skip ci]`
+- `netlify.toml` does not define a Production ignore/skip rule
+- Production branch remains intended to be `main`
+
+## Root-cause decision tree
+
+### 1. Confirm builds are active
+
+In Netlify:
+
+`Project configuration -> Build & deploy -> Continuous deployment -> Build settings`
+
+Expected:
+
+- Build status: `Active builds`
+
+If builds are stopped, activate builds before doing anything else. Activating builds alone does not create a new deploy; the next approved Git event must trigger the build.
+
+### 2. Confirm Production branch
+
+In:
+
+`Project configuration -> Build & deploy -> Continuous deployment -> Branches and deploy contexts`
+
+Expected:
+
+- Production branch: `main`
+
+Do not temporarily point Production at a feature branch to work around the incident.
+
+### 3. Confirm auto publishing is not locked
+
+On the Netlify Deploys page, verify the site is not locked and auto publishing is enabled.
+
+A locked deploy may allow newer Production builds to exist without making them the live deploy. If a newer `main` deploy exists but is unpublished, investigate why the lock was enabled before unlocking it.
+
+### 4. Inspect the exact current-main commit
+
+Search the Production deploy history for:
+
+`f99ec389a098477b46d37136aa7339b52b30c17a`
+
+Classify the result:
+
+- no deploy exists -> investigate GitHub App / repository integration event delivery
+- failed deploy -> inspect build logs and fix the actual failure
+- skipped deploy -> inspect skip reason / build configuration
+- ready but unpublished -> inspect auto-publish lock
+- ready and published -> verify the current Production pointer again
+
+Do not copy secrets, environment values, contact data, or authenticated state into the incident record.
+
+### 5. Confirm Git integration
+
+Verify the connected repository is still:
+
+`mizzz-ivr/ivmz-home`
+
+If the repository connection is broken, restore the Git integration without weakening `Enforce Git-based deployments`.
+
+## Diagnostic PR behavior
+
+This runbook change is intentionally a docs-only Draft PR created from the exact stale-gap `main` head.
+
+Its Deploy Preview is a non-Production diagnostic signal:
+
+- Deploy Preview created successfully -> Netlify can still receive/build current PR Git events; investigate Production branch / auto-publish behavior specifically
+- no Deploy Preview and no Netlify check -> investigate stopped builds or broken Git integration globally
+- Deploy Preview fails -> inspect the failure without weakening required checks
+
+The PR must not be merged only to force a Production deploy. Merge remains subject to the normal review and explicit owner approval policy.
+
+## Recovery acceptance
+
+Issue #38 can be completed only when all of the following are true:
+
+1. GitHub `main` HEAD is reconfirmed immediately before acceptance.
+2. latest main CI is success.
+3. Netlify current Production `commit_ref` equals that exact `main` HEAD.
+4. Production state is `ready`.
+5. Next.js Netlify plugin state is success.
+6. secret scan has zero matches.
+7. public read-only smoke is healthy.
+8. Payload published read remains healthy.
+9. Production CSP remains Report-Only until Issue #29 explicitly advances enforcement.
+10. the root cause and recovery action are recorded without exposing secrets.
+
+## Guardrails
+
+- do not disable `Enforce Git-based deployments`
+- do not bypass GitHub `Protect main`
+- do not direct-push to `main`
+- do not use a manual/API Production deploy to conceal drift
+- do not rotate `PAYLOAD_SECRET` as part of this incident
+- do not modify Production database data
+- do not weaken Deploy Preview, CI, security, or secret-scanning checks


### PR DESCRIPTION
## Summary

Issue #38 のProduction Git synchronization incidentについて、Repository側のrunbookとして再現可能な切り分け・復旧acceptanceを追加します。

Refs #38

## Verified baseline

- GitHub `main`: `f99ec389a098477b46d37136aa7339b52b30c17a`
- main CI #345: success
- Netlify Production current deploy: `6a91749fbb00070008ddaf51`
- Netlify Production current commit: `7377189dcae4b67ea87f9e00058be42666db0619`
- current Production deploy metadata branch: `main`
- Production state: ready
- plugin state: success
- secret scan: 0 matches
- `manual_deploy=false`

Production remains healthy but stale relative to current `main`.

## 2026-09-01 credit-cycle recheck

One new docs-only PR event was created after the expected Netlify credit-cycle recovery. No Production action was triggered.

Current PR head:

- `b694e9c2446d2dad48b534734cea4dd10b8ac49c`
- CI #350: **success**
- Netlify Deploy Preview ID: `6a960d7f70b9550008a129ad`
- exact-head Deploy Preview: **ready**
- Netlify plugin state: **success**
- secret scan: **0 matches / 217 files**
- Netlify Preview Smoke #317: **success**
  - exact-head Preview wait: success
  - Payload public API preflight: success
  - Chromium / mobile WebKit Playwright smoke: success
  - Payload auth rate-limit 429 verification: success

This confirms that current Netlify build capacity is available again and PR Git events continue to reach Netlify normally.

It does **not** retroactively repair the missing Production deploy. Production remains on `7377189d...` until a legitimate reviewed `main` Git event validates the Production path.

## Failure domain now

Ruled out / revalidated:

- current global stopped-builds state
- current account/credit state blocking new PR builds
- complete GitHub/Netlify integration disconnect
- general inability to build the current repository
- repository-side `[skip netlify]` / `[skip ci]`
- repository Production ignore rule

Remaining Production-specific possibilities:

1. configured Production branch
2. project-level auto-publish / deploy lock
3. failed/skipped/unpublished Production deploy for `f99ec389...`
4. missed historical `main` push / Production trigger
5. Production-side repository binding inconsistency

## Added runbook

`docs/netlify-production-sync.md`

Covers:

- approved reviewed PR -> `main` -> Netlify Git path
- credit-cycle recheck probe
- configured Production branch check
- deploy lock / auto publishing check
- exact-current-main deploy classification
- Git integration check
- recovery acceptance
- connected-tool boundary
- security / secret / DB guardrails

## Safety

- no Production deploy triggered manually
- no Netlify environment change
- no secret value
- no DB change
- no CSP enforcement
- no `PAYLOAD_SECRET` rotation
- Production current deploy remained unchanged during diagnostics

## 2026-09-01 progression state

Repository owner directed the work to proceed. PR #39 is mergeable and all required validation is green, with zero reviews and zero unresolved review threads.

An attempt to transition this PR from Draft to Ready for review through the connected GitHub tool failed because the connector generated a GraphQL query containing unsupported field `Repository.fullDatabaseId`. The PR therefore remains Draft due to connector tooling, not repository state.

Current single manual UI action:

- GitHub PR #39 -> **Ready for review**

After that, merge still requires explicit repository-owner approval. The PR must not be merged without that approval.

## Current blocker

The connected Netlify surface can read the current project/deploy and known deploy IDs, but it does not expose:

1. configured Production branch controls
2. project-level auto-publish / deploy-lock controls
3. complete Production deploy-history search for `f99ec389...`
4. repository-binding configuration
5. account credit balance itself

The available direct deployment trigger is intentionally **not** used because Issue #38 requires restoring and validating the reviewed PR -> `main` -> Git integration path rather than masking drift with a direct/manual deployment.

The next decisive validation is a legitimate reviewed Git event to `main`.

## Merge policy

Do not merge without explicit repository-owner approval. Do not use a manual/API Netlify deployment to bypass the Git-only recovery path.